### PR TITLE
[FIX] Google搜索使用模糊匹配以避免无结果

### DIFF
--- a/backend_api_python/app/services/agents/tools.py
+++ b/backend_api_python/app/services/agents/tools.py
@@ -525,13 +525,13 @@ class AgentTools:
             
             if market == 'AShare':
                 # AShare CN keywords
-                search_query = f'"{search_name}" {symbol} (利好 OR 利空 OR 财报 OR 公告 OR 业绩) after:{datetime.now().year-1}'
+                search_query = f'{search_name} {symbol} (利好 OR 利空 OR 财报 OR 公告 OR 业绩) after:{datetime.now().year-1}'
             elif market == 'HShare':
-                search_query = f'"{search_name}" {symbol} (港股 OR 股价 OR 业绩) after:{datetime.now().year-1}'
+                search_query = f'{search_name} {symbol} (港股 OR 股价 OR 业绩) after:{datetime.now().year-1}'
             elif market == 'Crypto':
-                search_query = f'"{search_name}" {symbol} crypto news analysis'
+                search_query = f'{search_name} {symbol} crypto news analysis'
             else:
-                search_query = f'"{search_name}" {symbol} stock news'
+                search_query = f'{search_name} {symbol} stock news'
             
             logger.info(f"Running news search: {search_query}")
             # Google CSE uses `dateRestrict` as a separate param; SearchService supports it.


### PR DESCRIPTION
由于 Google Custom Search 在使用精确匹配（带双引号）时，对于某些包含特殊字符的动态生成的查询词（如 `"BTC/USDT Cryptocurrency"`）可能返回0结果。

此修复移除了搜索关键词的强制双引号，改为模糊匹配，以提高搜索结果的覆盖率和鲁棒性。

已在本地进行验证，模糊匹配能有效返回相关新闻结果。