### PR TITLE
Potential fix for code scanning alert no. 254: Code injection

### DIFF
--- a/backend_api_python/app/routes/backtest.py
+++ b/backend_api_python/app/routes/backtest.py
@@ -13,6 +13,7 @@ from app.services.backtest import BacktestService
 from app.utils.logger import get_logger
 from app.utils.db import get_db_connection
 from app.utils.auth import login_required
+from app.utils.safe_exec import validate_code_safety
 import requests
 
 logger = get_logger(__name__)
@@ -174,6 +175,13 @@ def run_backtest():
         # Extract params - use current user's ID
         user_id = g.user_id
         indicator_code = data.get('indicatorCode', '')
+        is_safe_code, unsafe_reason = validate_code_safety(indicator_code or '')
+        if not is_safe_code:
+            return jsonify({
+                'code': 0,
+                'msg': f'Unsafe indicator code: {unsafe_reason}',
+                'data': None
+            }), 400
         indicator_id = data.get('indicatorId')
         symbol = data.get('symbol', '')
         market = data.get('market', '')

--- a/backend_api_python/app/utils/safe_exec.py
+++ b/backend_api_python/app/utils/safe_exec.py
@@ -411,11 +411,12 @@ def validate_code_safety(code: str) -> Tuple[bool, Optional[str]]:
     try:
         tree = ast.parse(code)
     except SyntaxError as e:
-        return False, f"代码语法错误: {e}"
+        logger.warning(f"Code syntax validation failed: {e}")
+        return False, "代码语法错误"
     except Exception as e:
         # AST parse failure → reject (fail-closed, not fail-open)
-        logger.error(f"AST parse failed, rejecting code: {e}")
-        return False, f"代码解析失败: {e}"
+        logger.exception("AST parse failed, rejecting code")
+        return False, "代码解析失败"
 
     dangerous_modules = {
         'os', 'sys', 'subprocess', 'shutil', 'signal', 'resource',


### PR DESCRIPTION
Potential fix for [https://github.com/brokermr810/QuantDinger/security/code-scanning/254](https://github.com/brokermr810/QuantDinger/security/code-scanning/254)

通用修复思路：对所有来自 HTTP 的脚本代码，在进入 service 执行链前进行显式安全校验；未通过即返回 400，阻断 tainted 数据到 `exec`。保留 `safe_exec_with_validation` 内部校验作为第二道防线。

本次最佳单一修复方案（不改变既有功能）：
1. 在 `backend_api_python/app/routes/backtest.py` 中增加对 `indicator_code` 的执行前校验（调用 `app.utils.safe_exec.validate_code_safety`）。
2. 在提取 `indicator_code` 后、调用 `backtest_service.run/run_multi_timeframe` 前，若校验失败直接返回统一错误响应。
3. 该改动不影响合法脚本执行流程，仅提前拒绝危险脚本，且可同时缓解同一 sink 的多变体告警。

需要的实现要点：
- 新增 import：`from app.utils.safe_exec import validate_code_safety`
- 新增校验逻辑与错误返回分支（位于 `indicator_code` 读取之后）


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
