### PR TITLE
feat(llm): add MiniMax-M2.7 provider support

### DIFF
--- a/backend_api_python/app/config/api_keys.py
+++ b/backend_api_python/app/config/api_keys.py
@@ -99,6 +99,16 @@ class MetaAPIKeys(type):
         from app.utils.config_loader import load_addon_config
         val = load_addon_config().get('grok', {}).get('api_key')
         return val if val else ''
+
+    @property
+    def MINIMAX_API_KEY(cls):
+        """MiniMax API key"""
+        env_val = os.getenv('MINIMAX_API_KEY', '').strip()
+        if env_val:
+            return env_val
+        from app.utils.config_loader import load_addon_config
+        val = load_addon_config().get('minimax', {}).get('api_key')
+        return val if val else ''
     
     @property
     def TAVILY_API_KEYS(cls):

--- a/backend_api_python/app/routes/settings.py
+++ b/backend_api_python/app/routes/settings.py
@@ -131,6 +131,7 @@ CONFIG_SCHEMA = {
                     {'value': 'google', 'label': 'Google Gemini'},
                     {'value': 'deepseek', 'label': 'DeepSeek'},
                     {'value': 'grok', 'label': 'xAI Grok'},
+                    {'value': 'minimax', 'label': 'MiniMax'},
                 ],
                 'description': 'Select your preferred LLM provider'
             },
@@ -262,6 +263,33 @@ CONFIG_SCHEMA = {
                 'default': 'https://api.x.ai/v1',
                 'description': 'xAI Grok API endpoint',
                 'group': 'grok'
+            },
+            # MiniMax
+            {
+                'key': 'MINIMAX_API_KEY',
+                'label': 'MiniMax API Key',
+                'type': 'password',
+                'required': False,
+                'link': 'https://platform.minimax.io',
+                'link_text': 'settings.link.getApiKey',
+                'description': 'MiniMax API key',
+                'group': 'minimax'
+            },
+            {
+                'key': 'MINIMAX_MODEL',
+                'label': 'MiniMax Model',
+                'type': 'text',
+                'default': 'MiniMax-M2.7',
+                'description': 'Model: MiniMax-M2.7, MiniMax-M2.7-highspeed',
+                'group': 'minimax'
+            },
+            {
+                'key': 'MINIMAX_BASE_URL',
+                'label': 'MiniMax Base URL',
+                'type': 'text',
+                'default': 'https://api.minimax.io/v1',
+                'description': 'MiniMax API endpoint',
+                'group': 'minimax'
             },
             # Common settings
             {

--- a/backend_api_python/app/services/llm.py
+++ b/backend_api_python/app/services/llm.py
@@ -1,6 +1,6 @@
 """
 LLM service.
-Supports multiple providers: OpenRouter, OpenAI, Google Gemini, DeepSeek, Grok.
+Supports multiple providers: OpenRouter, OpenAI, Google Gemini, DeepSeek, Grok, MiniMax.
 Kept separate from AnalysisService to avoid circular imports.
 """
 import json
@@ -23,6 +23,7 @@ class LLMProvider(Enum):
     GOOGLE = "google"
     DEEPSEEK = "deepseek"
     GROK = "grok"
+    MINIMAX = "minimax"
 
 
 # Provider configurations
@@ -52,6 +53,11 @@ PROVIDER_CONFIGS = {
         "default_model": "grok-beta",
         "fallback_model": "grok-beta",
     },
+    LLMProvider.MINIMAX: {
+        "base_url": "https://api.minimax.io/v1",
+        "default_model": "MiniMax-M2.7",
+        "fallback_model": "MiniMax-M2.7-highspeed",
+    },
 }
 
 
@@ -61,9 +67,9 @@ class LLMService:
     def __init__(self, provider: str = None):
         """
         Initialize LLM service.
-        
+
         Args:
-            provider: Override the default provider (openrouter, openai, google, deepseek, grok)
+            provider: Override the default provider (openrouter, openai, google, deepseek, grok, minimax)
         """
         self._provider_override = provider
 
@@ -90,10 +96,11 @@ class LLMService:
                 pass
         
         # Auto-detect: find any provider with a configured API key
-        # Priority: DeepSeek > Grok > OpenAI > Google > OpenRouter
+        # Priority: DeepSeek > Grok > MiniMax > OpenAI > Google > OpenRouter
         priority_order = [
             LLMProvider.DEEPSEEK,
             LLMProvider.GROK,
+            LLMProvider.MINIMAX,
             LLMProvider.OPENAI,
             LLMProvider.GOOGLE,
             LLMProvider.OPENROUTER,
@@ -117,6 +124,7 @@ class LLMService:
             LLMProvider.GOOGLE: APIKeys.GOOGLE_API_KEY,
             LLMProvider.DEEPSEEK: APIKeys.DEEPSEEK_API_KEY,
             LLMProvider.GROK: APIKeys.GROK_API_KEY,
+            LLMProvider.MINIMAX: APIKeys.MINIMAX_API_KEY,
         }
         return key_map.get(p, "") or ""
 
@@ -308,6 +316,7 @@ class LLMService:
                 'deepseek': LLMProvider.DEEPSEEK,
                 'x-ai': LLMProvider.GROK,
                 'xai': LLMProvider.GROK,
+                'minimax': LLMProvider.MINIMAX,
             }
             
             # If the model prefix matches the current provider, use the extracted model name
@@ -339,6 +348,7 @@ class LLMService:
             'deepseek': LLMProvider.DEEPSEEK,
             'x-ai': LLMProvider.GROK,
             'xai': LLMProvider.GROK,
+            'minimax': LLMProvider.MINIMAX,
             'anthropic': LLMProvider.OPENROUTER,  # Anthropic only via OpenRouter
             'meta': LLMProvider.OPENROUTER,  # Meta/Llama only via OpenRouter
             'mistral': LLMProvider.OPENROUTER,  # Mistral only via OpenRouter
@@ -399,7 +409,7 @@ class LLMService:
                 )
             # If no API key for current provider, try to find any available provider
             if try_alternative_providers:
-                for alt_provider in [LLMProvider.DEEPSEEK, LLMProvider.GROK, LLMProvider.OPENAI, LLMProvider.GOOGLE, LLMProvider.OPENROUTER]:
+                for alt_provider in [LLMProvider.DEEPSEEK, LLMProvider.GROK, LLMProvider.MINIMAX, LLMProvider.OPENAI, LLMProvider.GOOGLE, LLMProvider.OPENROUTER]:
                     if alt_provider != p and self.get_api_key(alt_provider):
                         logger.warning(f"No API key for {p.value}, switching to {alt_provider.value}")
                         p = alt_provider
@@ -494,12 +504,13 @@ class LLMService:
                                   use_json_mode: bool, excluded_provider: LLMProvider = None) -> str:
         """
         Try alternative providers when current provider fails.
-        
-        Priority: DeepSeek > Grok > OpenAI > Google > OpenRouter
+
+        Priority: DeepSeek > Grok > MiniMax > OpenAI > Google > OpenRouter
         """
         priority_order = [
             LLMProvider.DEEPSEEK,
             LLMProvider.GROK,
+            LLMProvider.MINIMAX,
             LLMProvider.OPENAI,
             LLMProvider.GOOGLE,
             LLMProvider.OPENROUTER,

--- a/backend_api_python/app/utils/config_loader.py
+++ b/backend_api_python/app/utils/config_loader.py
@@ -88,6 +88,11 @@ def load_addon_config() -> Dict[str, Any]:
         ('GROK_API_KEY', 'grok.api_key', 'string'),
         ('GROK_BASE_URL', 'grok.base_url', 'string'),
         ('GROK_MODEL', 'grok.model', 'string'),
+
+        # MiniMax
+        ('MINIMAX_API_KEY', 'minimax.api_key', 'string'),
+        ('MINIMAX_BASE_URL', 'minimax.base_url', 'string'),
+        ('MINIMAX_MODEL', 'minimax.model', 'string'),
         
         # LLM Provider Selection
         ('LLM_PROVIDER', 'llm.provider', 'string'),

--- a/backend_api_python/env.example
+++ b/backend_api_python/env.example
@@ -82,6 +82,9 @@ DEEPSEEK_MODEL=deepseek-chat
 GROK_API_KEY=
 GROK_MODEL=grok-beta
 
+MINIMAX_API_KEY=
+MINIMAX_MODEL=MiniMax-M2.7
+
 # =========================
 # Common background jobs
 # =========================
@@ -192,6 +195,7 @@ OPENROUTER_CONNECT_TIMEOUT=30
 OPENAI_BASE_URL=https://api.openai.com/v1
 DEEPSEEK_BASE_URL=https://api.deepseek.com/v1
 GROK_BASE_URL=https://api.x.ai/v1
+MINIMAX_BASE_URL=https://api.minimax.io/v1
 
 # Data sources
 DATA_SOURCE_TIMEOUT=30


### PR DESCRIPTION
## Summary

This PR adds [MiniMax](https://platform.minimax.io) as a supported LLM provider, alongside the existing OpenRouter, OpenAI, Google Gemini, DeepSeek, and Grok providers.

MiniMax offers two chat models:
- **MiniMax-M2.7** — Peak Performance, Ultimate Value (default)
- **MiniMax-M2.7-highspeed** — Same performance, faster and more agile

Because MiniMax exposes an OpenAI-compatible REST API, no new HTTP client code is needed — the existing `_call_openai_compatible()` method handles all requests.

## Changes

| File | What changed |
|------|-------------|
| `app/services/llm.py` | `LLMProvider.MINIMAX` enum value; provider config with base URL, default model, and fallback; API key mapping; model prefix detection/normalization for `minimax/`; MiniMax in auto-detection and fallback priority lists |
| `app/config/api_keys.py` | `MINIMAX_API_KEY` metaclass property (reads from `MINIMAX_API_KEY` env var or `minimax.api_key` config key) |
| `app/utils/config_loader.py` | `MINIMAX_API_KEY`, `MINIMAX_BASE_URL`, `MINIMAX_MODEL` environment variable mappings |
| `app/routes/settings.py` | MiniMax option in the LLM provider selector; API key, model, and base-URL settings items |
| `env.example` | `MINIMAX_API_KEY`, `MINIMAX_MODEL`, `MINIMAX_BASE_URL` documented |

## Configuration

```env
LLM_PROVIDER=minimax
MINIMAX_API_KEY=your-key-here
MINIMAX_MODEL=MiniMax-M2.7
MINIMAX_BASE_URL=https://api.minimax.io/v1
```

## How to test

1. Obtain a MiniMax API key from https://platform.minimax.io
2. Set `LLM_PROVIDER=minimax` and `MINIMAX_API_KEY=<your-key>` in `backend_api_python/.env`
3. Start the backend and run an AI analysis
4. Verify the provider appears in Settings → AI/LLM section of the UI