### PR TITLE
feat(data): add MOEX (Moscow Exchange) equities data source (analysis/backtest only)

### DIFF
--- a/backend_api_python/app/data_sources/factory.py
+++ b/backend_api_python/app/data_sources/factory.py
@@ -21,6 +21,11 @@ _MARKET_ALIASES: Dict[str, str] = {
     "cnstock": "CNStock",
     "hkstock": "HKStock",
     "futures": "Futures",
+    "moex": "MOEX",
+    "rustock": "MOEX",
+    "rustocks": "MOEX",
+    "russianstock": "MOEX",
+    "russia": "MOEX",
 }
 
 
@@ -38,7 +43,7 @@ class DataSourceFactory:
         if not market:
             return "Crypto"
         raw = str(market).strip()
-        if raw in ("Crypto", "Forex", "Futures", "USStock", "CNStock", "HKStock"):
+        if raw in ("Crypto", "Forex", "Futures", "USStock", "CNStock", "HKStock", "MOEX"):
             return raw
         key = raw.lower().replace(" ", "").replace("-", "_")
         return _MARKET_ALIASES.get(key, raw)
@@ -98,6 +103,9 @@ class DataSourceFactory:
         elif market == 'Futures':
             from app.data_sources.futures import FuturesDataSource
             return FuturesDataSource()
+        elif market == 'MOEX':
+            from app.data_sources.moex import MOEXDataSource
+            return MOEXDataSource()
         else:
             raise ValueError(f"不支持的市场类型: {market}")
     

--- a/backend_api_python/app/data_sources/moex.py
+++ b/backend_api_python/app/data_sources/moex.py
@@ -1,0 +1,304 @@
+"""
+MOEX (Moscow Exchange) equities data source.
+
+Read-only data source for analysis and backtesting that uses the MOEX ISS public
+HTTP API (https://iss.moex.com/iss/reference/). Supports Russian equities listed
+on the TQBR board (e.g. SBER, GAZP, LKOH).
+
+Live order placement is intentionally NOT implemented — this source only exposes
+historical candles and last-trade ticker data.
+
+ISS candle intervals (minutes):
+    1, 10, 60, 24 (=day), 7 (=week), 31 (=month)
+
+QuantDinger timeframes are mapped to the closest ISS interval.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional
+
+import requests
+
+from app.data_sources.base import BaseDataSource, TIMEFRAME_SECONDS
+from app.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+# QuantDinger timeframe -> MOEX ISS candle interval (minutes; 24=day, 7=week, 31=month)
+# 5m / 15m / 30m / 4H are not natively offered by ISS; we resample from the
+# nearest finer interval (1m for sub-hour, 60m for 4H).
+INTERVAL_MAP: Dict[str, int] = {
+    '1m': 1,
+    '5m': 1,
+    '15m': 1,
+    '30m': 1,
+    '1H': 60,
+    '4H': 60,
+    '1D': 24,
+    '1W': 7,
+}
+
+# Native ISS interval set per timeframe -- used to decide whether resampling is needed.
+_NATIVE_ISS = {'1m': 1, '1H': 60, '1D': 24, '1W': 7}
+
+ISS_BASE = "https://iss.moex.com/iss"
+DEFAULT_BOARD = "TQBR"  # main equities board (T+ settlement)
+DEFAULT_ENGINE = "stock"
+DEFAULT_MARKET = "shares"
+HTTP_TIMEOUT = 15
+
+
+class MOEXDataSource(BaseDataSource):
+    """Moscow Exchange (MOEX) equities — analysis & backtest only."""
+
+    name = "MOEX/iss"
+
+    def __init__(self, board: str = DEFAULT_BOARD):
+        self.board = board
+        self._session = requests.Session()
+        self._session.headers.update({"User-Agent": "QuantDinger/MOEX-DataSource"})
+
+    # ------------------------------------------------------------------ helpers
+    @staticmethod
+    def _normalize_symbol(symbol: str) -> str:
+        """Strip exchange suffixes / whitespace and uppercase. e.g. 'sber.me' -> 'SBER'."""
+        if not symbol:
+            return ""
+        s = str(symbol).strip().upper()
+        for suffix in (".ME", ".MOEX", ":MOEX", "@MOEX"):
+            if s.endswith(suffix):
+                s = s[: -len(suffix)]
+                break
+        return s
+
+    def _candle_url(self, symbol: str) -> str:
+        return (
+            f"{ISS_BASE}/engines/{DEFAULT_ENGINE}/markets/{DEFAULT_MARKET}"
+            f"/boards/{self.board}/securities/{symbol}/candles.json"
+        )
+
+    def _securities_url(self, symbol: str) -> str:
+        return (
+            f"{ISS_BASE}/engines/{DEFAULT_ENGINE}/markets/{DEFAULT_MARKET}"
+            f"/boards/{self.board}/securities/{symbol}.json"
+        )
+
+    def _http_get(self, url: str, params: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        try:
+            resp = self._session.get(url, params=params, timeout=HTTP_TIMEOUT)
+            if resp.status_code != 200:
+                logger.warning(f"MOEX ISS HTTP {resp.status_code} for {url}")
+                return None
+            return resp.json()
+        except Exception as e:
+            logger.warning(f"MOEX ISS request failed ({url}): {e}")
+            return None
+
+    @staticmethod
+    def _moex_dt_to_unix(dt_str: str) -> Optional[int]:
+        """ISS returns naive Moscow-time timestamps like '2025-01-10 10:00:00'.
+        Treat them as Europe/Moscow (UTC+3, no DST since 2014) and convert to Unix UTC seconds.
+        """
+        if not dt_str:
+            return None
+        try:
+            dt = datetime.strptime(dt_str, "%Y-%m-%d %H:%M:%S")
+        except ValueError:
+            try:
+                dt = datetime.strptime(dt_str, "%Y-%m-%d")
+            except ValueError:
+                return None
+        msk = timezone(timedelta(hours=3))
+        return int(dt.replace(tzinfo=msk).timestamp())
+
+    @staticmethod
+    def _resample(klines: List[Dict[str, Any]], target_seconds: int) -> List[Dict[str, Any]]:
+        """Aggregate a sorted list of finer-interval candles into target_seconds buckets."""
+        if not klines or target_seconds <= 0:
+            return klines
+        out: List[Dict[str, Any]] = []
+        current: Optional[Dict[str, Any]] = None
+        bucket_start = -1
+        for k in klines:
+            ts = int(k['time'])
+            b = ts - (ts % target_seconds)
+            if current is None or b != bucket_start:
+                if current is not None:
+                    out.append(current)
+                current = {
+                    'time': b,
+                    'open': k['open'],
+                    'high': k['high'],
+                    'low': k['low'],
+                    'close': k['close'],
+                    'volume': k['volume'],
+                }
+                bucket_start = b
+            else:
+                current['high'] = max(current['high'], k['high'])
+                current['low'] = min(current['low'], k['low'])
+                current['close'] = k['close']
+                current['volume'] = round(current['volume'] + k['volume'], 2)
+        if current is not None:
+            out.append(current)
+        return out
+
+    # ------------------------------------------------------------------ public
+    def get_kline(
+        self,
+        symbol: str,
+        timeframe: str,
+        limit: int,
+        before_time: Optional[int] = None,
+        after_time: Optional[int] = None,
+    ) -> List[Dict[str, Any]]:
+        sym = self._normalize_symbol(symbol)
+        if not sym:
+            return []
+
+        iss_interval = INTERVAL_MAP.get(timeframe)
+        if iss_interval is None:
+            logger.warning(f"MOEX: unsupported timeframe {timeframe}, defaulting to 1D")
+            iss_interval = 24
+            timeframe = '1D'
+        target_seconds = TIMEFRAME_SECONDS.get(timeframe, 86400)
+
+        # Date range: enough history to cover `limit` candles with weekend/holiday buffer.
+        end_dt = datetime.fromtimestamp(before_time, tz=timezone.utc) if before_time else datetime.now(tz=timezone.utc)
+        # ISS uses local (Moscow) date strings; using UTC date is acceptable for from/till bounds.
+        # For minute data, ISS returns at most 500 rows per page — we paginate via `start`.
+        if timeframe in ('1m', '5m', '15m', '30m'):
+            # ~7h trading day -> ~420 1m bars; assume ≤390 bars/day, add safety
+            days = max(2, int(limit / 300) + 2)
+        elif timeframe == '1H':
+            days = max(5, int(limit / 7) + 3)
+        elif timeframe == '4H':
+            days = max(15, int(limit / 2) + 5)
+        elif timeframe == '1W':
+            days = max(60, limit * 7 + 14)
+        else:  # 1D
+            days = max(7, int(limit * 1.6) + 5)
+        start_dt = end_dt - timedelta(days=days)
+        if after_time is not None:
+            start_dt = min(start_dt, datetime.fromtimestamp(after_time, tz=timezone.utc))
+
+        url = self._candle_url(sym)
+        all_rows: List[List[Any]] = []
+        col_idx: Dict[str, int] = {}
+        start = 0
+        page_size = 500  # ISS default cap for candles
+        max_pages = 50  # hard safety cap (25k rows)
+
+        for _ in range(max_pages):
+            params = {
+                'from': start_dt.strftime('%Y-%m-%d'),
+                'till': end_dt.strftime('%Y-%m-%d'),
+                'interval': iss_interval,
+                'start': start,
+            }
+            payload = self._http_get(url, params)
+            if not payload:
+                break
+            block = payload.get('candles') or {}
+            data = block.get('data') or []
+            if not col_idx:
+                cols = block.get('columns') or []
+                col_idx = {c: i for i, c in enumerate(cols)}
+            all_rows.extend(data)
+            if len(data) < page_size:
+                break
+            start += len(data)
+
+        if not col_idx:
+            logger.info(f"MOEX: empty candles response for {sym} ({timeframe})")
+            return []
+
+        i_open = col_idx.get('open')
+        i_close = col_idx.get('close')
+        i_high = col_idx.get('high')
+        i_low = col_idx.get('low')
+        i_vol = col_idx.get('volume')
+        i_begin = col_idx.get('begin')
+        if None in (i_open, i_close, i_high, i_low, i_vol, i_begin):
+            logger.warning(f"MOEX: unexpected candle columns for {sym}: {col_idx}")
+            return []
+
+        klines: List[Dict[str, Any]] = []
+        for row in all_rows:
+            try:
+                ts = self._moex_dt_to_unix(row[i_begin])
+                if ts is None:
+                    continue
+                klines.append(self.format_kline(
+                    timestamp=ts,
+                    open_price=row[i_open] or 0,
+                    high=row[i_high] or 0,
+                    low=row[i_low] or 0,
+                    close=row[i_close] or 0,
+                    volume=row[i_vol] or 0,
+                ))
+            except Exception as e:
+                logger.debug(f"MOEX: failed to parse candle row {row}: {e}")
+                continue
+
+        # Resample for non-native intervals (5/15/30m, 4H)
+        if timeframe not in _NATIVE_ISS:
+            klines.sort(key=lambda x: x['time'])
+            klines = self._resample(klines, target_seconds)
+
+        klines = self.filter_and_limit(
+            klines,
+            limit,
+            before_time,
+            after_time,
+            truncate=(after_time is None),
+        )
+        self.log_result(sym, klines, timeframe)
+        return klines
+
+    def get_ticker(self, symbol: str) -> Dict[str, Any]:
+        """Latest quote via ISS securities snapshot. Returns dict with 'last', 'change', etc."""
+        sym = self._normalize_symbol(symbol)
+        if not sym:
+            return {'last': 0, 'symbol': symbol}
+        payload = self._http_get(self._securities_url(sym), {'iss.meta': 'off'})
+        if not payload:
+            return {'last': 0, 'symbol': sym}
+
+        marketdata = payload.get('marketdata') or {}
+        md_cols = marketdata.get('columns') or []
+        md_data = marketdata.get('data') or []
+        if not md_data:
+            return {'last': 0, 'symbol': sym}
+        idx = {c: i for i, c in enumerate(md_cols)}
+        row = md_data[0]
+
+        def _pick(*names) -> float:
+            for n in names:
+                i = idx.get(n)
+                if i is not None and row[i] is not None:
+                    try:
+                        return float(row[i])
+                    except (TypeError, ValueError):
+                        continue
+            return 0.0
+
+        last = _pick('LAST', 'LCURRENTPRICE', 'MARKETPRICE', 'LCLOSEPRICE')
+        prev_close = _pick('LCLOSEPRICE', 'PREVPRICE', 'PREVADMITTEDQUOTE')
+        high = _pick('HIGH')
+        low = _pick('LOW')
+        open_p = _pick('OPEN')
+        change = round(last - prev_close, 4) if (last and prev_close) else 0.0
+        change_pct = round((change / prev_close) * 100, 2) if prev_close else 0.0
+        return {
+            'last': last,
+            'change': change,
+            'changePercent': change_pct,
+            'high': high,
+            'low': low,
+            'open': open_p,
+            'previousClose': prev_close,
+            'symbol': sym,
+        }

--- a/backend_api_python/app/routes/market.py
+++ b/backend_api_python/app/routes/market.py
@@ -94,7 +94,7 @@ def get_public_config():
 def get_market_types():
     """Return supported market types for the add-watchlist modal."""
     # Keep a stable UX order; add CN/HK stocks near US stocks.
-    desired_order = ['USStock', 'CNStock', 'HKStock', 'Crypto', 'Forex', 'Futures']
+    desired_order = ['USStock', 'CNStock', 'HKStock', 'MOEX', 'Crypto', 'Forex', 'Futures']
     order_rank = {v: i for i, v in enumerate(desired_order)}
 
     def _normalize_item(x):

--- a/backend_api_python/app/services/strategy.py
+++ b/backend_api_python/app/services/strategy.py
@@ -958,6 +958,11 @@ class StrategyService:
                 f"IBKR can only be used for US stock trading, but market_category is '{market_category}'. "
                 f"Please set market category to US Stock when using Interactive Brokers."
             )
+        if market_category == 'MOEX':
+            raise ValueError(
+                "MOEX (Moscow Exchange) is supported for analysis and backtesting only. "
+                "Live order placement on MOEX is not implemented."
+            )
 
         # When credential_id is present, strip raw API keys to avoid
         # storing secrets in the strategy record — they live in qd_exchange_credentials.
@@ -1076,7 +1081,12 @@ class StrategyService:
                 f"IBKR can only be used for US stock trading, but market_category is '{market_category}'. "
                 f"Please set market category to US Stock when using Interactive Brokers."
             )
-        
+        if market_category == 'MOEX':
+            raise ValueError(
+                "MOEX (Moscow Exchange) is supported for analysis and backtesting only. "
+                "Live order placement on MOEX is not implemented."
+            )
+
         # Generate strategy group ID
         strategy_group_id = str(uuid.uuid4())[:8]
         
@@ -1276,6 +1286,11 @@ class StrategyService:
         if ex_id == 'ibkr' and market_category != 'USStock':
             raise ValueError(
                 f"IBKR can only be used for US stock trading, but market_category is '{market_category}'."
+            )
+        if market_category == 'MOEX':
+            raise ValueError(
+                "MOEX (Moscow Exchange) is supported for analysis and backtesting only. "
+                "Live order placement on MOEX is not implemented."
             )
 
         symbol = (trading_config or {}).get('symbol')

--- a/backend_api_python/app/services/symbol_name.py
+++ b/backend_api_python/app/services/symbol_name.py
@@ -121,6 +121,31 @@ def resolve_symbol_name(market: str, symbol: str) -> Optional[str]:
             pass
         return _resolve_name_from_yfinance(s)
 
+    # MOEX (Russian equities): try MOEX ISS securities description for a name.
+    if m == 'MOEX':
+        try:
+            from app.data_sources.moex import MOEXDataSource, ISS_BASE
+            sym = MOEXDataSource._normalize_symbol(s)
+            url = f"{ISS_BASE}/securities/{sym}.json"
+            resp = requests.get(url, params={"iss.meta": "off"}, timeout=8)
+            if resp.status_code == 200:
+                payload = resp.json() or {}
+                desc = (payload.get('description') or {})
+                cols = desc.get('columns') or []
+                data = desc.get('data') or []
+                if cols and data:
+                    name_idx = cols.index('name') if 'name' in cols else None
+                    val_idx = cols.index('value') if 'value' in cols else None
+                    if name_idx is not None and val_idx is not None:
+                        for row in data:
+                            if row[name_idx] in ('SHORTNAME', 'SECNAME'):
+                                v = (row[val_idx] or '').strip()
+                                if v:
+                                    return v
+        except Exception as e:
+            logger.debug(f"MOEX name resolve failed: {symbol}: {e}")
+        return s
+
     # Crypto: at least return base ticker-like display (not a "company", but better than empty)
     if m == 'Crypto':
         if '/' in s:

--- a/backend_api_python/scripts/verify_moex.py
+++ b/backend_api_python/scripts/verify_moex.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Live verification script for the MOEX data source.
+
+Hits the public MOEX ISS API. Run from the backend_api_python directory:
+
+    python scripts/verify_moex.py
+    python scripts/verify_moex.py SBER 1D 30
+    python scripts/verify_moex.py GAZP 1H 50
+
+Prints a summary of fetched candles and the latest ticker. Useful for smoke-
+testing connectivity in environments where pytest can run only offline tests.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from datetime import datetime, timezone
+
+# Make `app` importable when the script is run directly
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+# Minimal env so app.config doesn't blow up
+os.environ.setdefault("SECRET_KEY", "verify-moex-script")
+os.environ.setdefault("ADMIN_USER", "verify")
+os.environ.setdefault("ADMIN_PASSWORD", "verifypass")
+
+from app.data_sources.factory import DataSourceFactory  # noqa: E402
+
+
+def main() -> int:
+    symbol = sys.argv[1] if len(sys.argv) > 1 else "SBER"
+    timeframe = sys.argv[2] if len(sys.argv) > 2 else "1D"
+    limit = int(sys.argv[3]) if len(sys.argv) > 3 else 10
+
+    print(f"== MOEX verification ==  symbol={symbol} timeframe={timeframe} limit={limit}")
+    src = DataSourceFactory.get_source("MOEX")
+    print(f"data source: {src.name}")
+
+    klines = src.get_kline(symbol, timeframe, limit)
+    print(f"candles returned: {len(klines)}")
+    for k in klines[-5:]:
+        utc = datetime.fromtimestamp(k['time'], tz=timezone.utc).isoformat()
+        print(f"  {utc}  O={k['open']:>8} H={k['high']:>8} L={k['low']:>8} C={k['close']:>8} V={k['volume']}")
+
+    print()
+    ticker = src.get_ticker(symbol)
+    print(f"ticker: {ticker}")
+
+    if not klines:
+        print("WARNING: no candles returned (network blocked? bad symbol? non-trading window?)")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend_api_python/tests/test_moex_data_source.py
+++ b/backend_api_python/tests/test_moex_data_source.py
@@ -1,0 +1,156 @@
+"""Unit tests for the MOEX (Moscow Exchange) data source.
+
+These tests do not hit the real ISS API — they mock the HTTP layer.
+A separate verification script (scripts/verify_moex.py) exercises the live API.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from app.data_sources.factory import DataSourceFactory
+from app.data_sources.moex import INTERVAL_MAP, MOEXDataSource
+
+
+def _candle_payload(rows):
+    """Build a minimal MOEX ISS /candles.json payload."""
+    return {
+        "candles": {
+            "columns": ["open", "close", "high", "low", "value", "volume", "begin", "end"],
+            "data": rows,
+        }
+    }
+
+
+def test_factory_recognizes_moex():
+    assert DataSourceFactory.normalize_market("moex") == "MOEX"
+    assert DataSourceFactory.normalize_market("MOEX") == "MOEX"
+    assert DataSourceFactory.normalize_market("RuStocks") == "MOEX"
+    src = DataSourceFactory.get_source("MOEX")
+    assert isinstance(src, MOEXDataSource)
+
+
+def test_normalize_symbol_strips_suffixes():
+    assert MOEXDataSource._normalize_symbol("sber") == "SBER"
+    assert MOEXDataSource._normalize_symbol("SBER.ME") == "SBER"
+    assert MOEXDataSource._normalize_symbol("gazp.MOEX") == "GAZP"
+    assert MOEXDataSource._normalize_symbol("LKOH:MOEX") == "LKOH"
+    assert MOEXDataSource._normalize_symbol(" SBER ") == "SBER"
+
+
+def test_interval_map_covers_all_quantdinger_timeframes():
+    expected = {"1m", "5m", "15m", "30m", "1H", "4H", "1D", "1W"}
+    assert expected.issubset(set(INTERVAL_MAP.keys()))
+    # Native ISS intervals
+    assert INTERVAL_MAP["1m"] == 1
+    assert INTERVAL_MAP["1H"] == 60
+    assert INTERVAL_MAP["1D"] == 24
+    assert INTERVAL_MAP["1W"] == 7
+
+
+def test_moex_dt_to_unix_treats_naive_as_moscow():
+    # MSK is UTC+3 (year-round, no DST since 2014).
+    # 2025-01-10 12:00:00 MSK == 2025-01-10 09:00:00 UTC == 1736499600
+    ts = MOEXDataSource._moex_dt_to_unix("2025-01-10 12:00:00")
+    assert ts == 1736499600
+
+
+def test_get_kline_native_daily_parses_payload():
+    src = MOEXDataSource()
+    rows = [
+        # open, close, high, low, value, volume, begin,            end
+        [100.0, 101.0, 102.0, 99.0, 1000.0, 500.0, "2025-01-10 00:00:00", "2025-01-10 23:59:59"],
+        [101.0, 103.0, 104.0, 100.5, 1500.0, 700.0, "2025-01-13 00:00:00", "2025-01-13 23:59:59"],
+        [103.0, 102.0, 103.5, 101.0, 1100.0, 400.0, "2025-01-14 00:00:00", "2025-01-14 23:59:59"],
+    ]
+    with patch.object(src, "_http_get", return_value=_candle_payload(rows)):
+        out = src.get_kline("SBER", "1D", limit=10)
+    assert len(out) == 3
+    assert all({"time", "open", "high", "low", "close", "volume"} <= set(k.keys()) for k in out)
+    # Sorted ascending by time
+    assert out[0]["time"] < out[1]["time"] < out[2]["time"]
+    # First candle: 2025-01-10 00:00:00 MSK == 2025-01-09 21:00:00 UTC
+    assert out[0]["open"] == 100.0 and out[0]["close"] == 101.0
+
+
+def test_get_kline_resamples_15m_from_1m():
+    src = MOEXDataSource()
+    # Build 30 contiguous 1-minute candles starting at 2025-01-10 10:00:00 MSK
+    base = MOEXDataSource._moex_dt_to_unix("2025-01-10 10:00:00")
+    rows = []
+    for i in range(30):
+        ts = base + i * 60
+        # Construct begin string in MSK local time
+        from datetime import datetime, timedelta, timezone
+        msk = timezone(timedelta(hours=3))
+        begin = datetime.fromtimestamp(ts, tz=msk).strftime("%Y-%m-%d %H:%M:%S")
+        end = datetime.fromtimestamp(ts + 59, tz=msk).strftime("%Y-%m-%d %H:%M:%S")
+        rows.append([
+            100.0 + i, 100.5 + i, 101.0 + i, 99.5 + i, 10.0, 5.0, begin, end
+        ])
+
+    with patch.object(src, "_http_get", return_value=_candle_payload(rows)):
+        out = src.get_kline("SBER", "15m", limit=10)
+    # 30 minutes resampled into 15m buckets should yield exactly 2 bars
+    assert len(out) == 2
+    # Each 15m bar aggregates 15 1m bars
+    assert out[0]["volume"] == round(5.0 * 15, 2)
+    # Open of first bucket == open of first 1m candle; close == close of 15th
+    assert out[0]["open"] == 100.0
+    assert out[0]["close"] == 100.5 + 14
+
+
+def test_get_kline_returns_empty_on_http_failure():
+    src = MOEXDataSource()
+    with patch.object(src, "_http_get", return_value=None):
+        out = src.get_kline("UNKNOWN", "1D", limit=5)
+    assert out == []
+
+
+def test_get_kline_unsupported_timeframe_falls_back_to_daily():
+    src = MOEXDataSource()
+    rows = [
+        [100.0, 101.0, 102.0, 99.0, 1000.0, 500.0, "2025-01-10 00:00:00", "2025-01-10 23:59:59"],
+    ]
+    with patch.object(src, "_http_get", return_value=_candle_payload(rows)):
+        out = src.get_kline("SBER", "2D", limit=5)
+    assert len(out) == 1
+
+
+def test_resample_handles_empty():
+    assert MOEXDataSource._resample([], 900) == []
+
+
+def test_get_ticker_parses_marketdata():
+    src = MOEXDataSource()
+    payload = {
+        "marketdata": {
+            "columns": ["LAST", "LCLOSEPRICE", "OPEN", "HIGH", "LOW"],
+            "data": [[310.5, 305.0, 306.0, 312.0, 304.0]],
+        }
+    }
+    with patch.object(src, "_http_get", return_value=payload):
+        t = src.get_ticker("SBER")
+    assert t["last"] == 310.5
+    assert t["previousClose"] == 305.0
+    assert t["change"] == 5.5
+    # 5.5 / 305 * 100 ≈ 1.8
+    assert abs(t["changePercent"] - 1.8) < 0.05
+
+
+def test_live_trading_blocked_for_moex():
+    """The strategy service source must reject MOEX as a live-trading market_category.
+
+    Read the file directly rather than importing it — importing pulls heavy
+    optional deps (yfinance, etc.) that aren't required for offline tests.
+    """
+    import os
+    import app
+    app_pkg_dir = os.path.dirname(app.__file__)
+    strat_path = os.path.join(app_pkg_dir, "services", "strategy.py")
+    with open(strat_path, "r", encoding="utf-8") as f:
+        src = f.read()
+    # The guard appears in create / batch / update strategy paths.
+    assert src.count("market_category == 'MOEX'") >= 3
+    assert "Live order placement on MOEX is not implemented" in src


### PR DESCRIPTION
## Summary

Adds a read-only Moscow Exchange (MOEX) equities data source backed by the public [MOEX ISS](https://iss.moex.com/iss/reference/) HTTP API. Targets the `TQBR` board so common Russian tickers (`SBER`, `GAZP`, `LKOH`, `ROSN`, `NVTK`, …) work out of the box.

- **Read-only.** No live order placement on MOEX — an explicit guard in `app/services/strategy.py` rejects `market_category="MOEX"` in create / batch / update strategy paths.
- **Wired into the factory** like other equity sources, so candle / ticker requests via `DataSourceFactory.get_kline("MOEX", "SBER", "1D", 100)` just work.
- **Exposed in `/market/types`** so the existing add-watchlist modal can offer it (between `HKStock` and `Crypto`).
- **Symbol-name resolution** uses the ISS `/securities/{sec}.json` endpoint (`SHORTNAME` / `SECNAME`).

### Timeframe mapping
QuantDinger TF → MOEX ISS interval:

| TF  | ISS interval | Notes |
| --- | ------------ | ----- |
| 1m  | 1            | native |
| 5m  | 1 → resample | client-side aggregation |
| 15m | 1 → resample | client-side aggregation |
| 30m | 1 → resample | client-side aggregation |
| 1H  | 60           | native |
| 4H  | 60 → resample | client-side aggregation |
| 1D  | 24           | native |
| 1W  | 7            | native |

ISS returns naive timestamps in Moscow time; the source converts them to Unix UTC seconds (MSK = UTC+3 year-round, no DST since 2014).

## Files

- `backend_api_python/app/data_sources/moex.py` — new `MOEXDataSource`
- `backend_api_python/app/data_sources/factory.py` — register `MOEX` + aliases (`moex`, `rustock`, `russia`, …)
- `backend_api_python/app/routes/market.py` — include `MOEX` in `/market/types`
- `backend_api_python/app/services/symbol_name.py` — MOEX name resolver
- `backend_api_python/app/services/strategy.py` — block live trading for `market_category == 'MOEX'`
- `backend_api_python/tests/test_moex_data_source.py` — 11 offline unit tests
- `backend_api_python/scripts/verify_moex.py` — live ISS smoke-test script

## How to use

```python
from app.data_sources.factory import DataSourceFactory

# Daily candles for Sberbank
DataSourceFactory.get_kline("MOEX", "SBER", "1D", limit=100)

# 15-minute candles (auto-resampled from 1m)
DataSourceFactory.get_kline("MOEX", "GAZP", "15m", limit=50)

# Latest ticker
DataSourceFactory.get_ticker("MOEX", "LKOH")
```

Or via the existing kline route: `GET /api/kline?market=MOEX&symbol=SBER&timeframe=1D&limit=100`.

Smoke test:
```
cd backend_api_python && python scripts/verify_moex.py SBER 1D 5
```

## Limitations

- **No live trading.** This source is data-only.
- **TQBR board only by default.** Other MOEX boards (e.g. `SMAL`, `FQBR`) are reachable by constructing `MOEXDataSource(board=...)` directly; they're not exposed via the factory.
- **5m / 15m / 30m / 4H are resampled** client-side from native ISS intervals — fetching very large limits at fine timeframes pulls more raw data and is slower than native intervals.
- **Symbol search** in the existing `/symbols/search` endpoint is DB-seed driven; this PR does not seed MOEX tickers in `qd_market_symbols`. Users typing `SBER` directly (e.g. via the add-watchlist modal) will work because name resolution falls back to ISS.

## Test plan

- [x] `pytest tests/test_moex_data_source.py` — 11 passed (mocked HTTP)
- [x] Live smoke test against ISS: `python scripts/verify_moex.py SBER 1D 5` returned 5 daily candles + ticker
- [x] Live smoke test 15m resample: `python scripts/verify_moex.py GAZP 15m 8` returned 8 aggregated 15m bars
- [x] Verify MOEX appears in the watchlist add-modal (frontend, requires running stack)
- [ ] Verify a strategy created with `market_category="MOEX"` is rejected with the expected message

🤖 Generated with [Claude Code](https://claude.com/claude-code)