### PR TITLE
feat: add 3-minute K-line timeframe

### DIFF
--- a/backend_api_python/app/config/data_sources.py
+++ b/backend_api_python/app/config/data_sources.py
@@ -83,6 +83,7 @@ class MetaYFinanceConfig(type):
     def INTERVAL_MAP(cls):
         return {
             '1m': '1m',
+            '3m': '3m',
             '5m': '5m',
             '15m': '15m',
             '30m': '30m',
@@ -119,6 +120,7 @@ class MetaCCXTConfig(type):
     def TIMEFRAME_MAP(cls):
         return {
             '1m': '1m',
+            '3m': '3m',
             '5m': '5m',
             '15m': '15m',
             '30m': '30m',

--- a/backend_api_python/app/data_sources/asia_stock_kline.py
+++ b/backend_api_python/app/data_sources/asia_stock_kline.py
@@ -138,6 +138,7 @@ def _get_twelve_data_api_key() -> str:
 
 _TD_INTERVAL_MAP = {
     "1m": "1min",
+    "3m": "1min",
     "5m": "5min",
     "15m": "15min",
     "30m": "30min",
@@ -184,11 +185,12 @@ def fetch_twelvedata_klines(
         return []
 
     symbol, exchange = _td_symbol_and_exchange(tencent_code, is_hk)
+    merge_factor = _MERGE_FACTOR_MAP.get(timeframe, 1)
     params: Dict[str, Any] = {
         "symbol": symbol,
         "exchange": exchange,
         "interval": interval,
-        "outputsize": min(int(limit), 5000),
+        "outputsize": min(int(limit) * merge_factor, 5000),
         "apikey": api_key,
         "format": "JSON",
         "dp": "4",
@@ -260,6 +262,8 @@ def fetch_twelvedata_klines(
             continue
 
     out.sort(key=lambda x: x["time"])
+    if merge_factor > 1 and out:
+        out = _merge_every_n_sorted_bars(out, merge_factor)
     logger.debug("TwelveData returned %d bars for %s/%s tf=%s", len(out), symbol, exchange, timeframe)
     return out
 
@@ -288,6 +292,7 @@ def yf_symbol_from_tencent(tencent_code: str, is_hk: bool) -> str:
 
 _YF_INTERVAL_MAP = {
     "1m": "1m",
+    "3m": "1m",
     "5m": "5m",
     "15m": "15m",
     "30m": "30m",
@@ -295,6 +300,11 @@ _YF_INTERVAL_MAP = {
     "4H": "1h",
     "1D": "1d",
     "1W": "1wk",
+}
+
+_MERGE_FACTOR_MAP = {
+    "3m": 3,
+    "4H": 4,
 }
 
 _YF_DAYS_MAP = {
@@ -372,7 +382,8 @@ def fetch_yfinance_klines(
         return []
 
     yf_sym = yf_symbol_from_tencent(tencent_code, is_hk)
-    effective_limit = limit * 4 if timeframe == "4H" else limit
+    merge_factor = _MERGE_FACTOR_MAP.get(timeframe, 1)
+    effective_limit = limit * merge_factor
     days_func = _YF_DAYS_MAP.get(timeframe, lambda x: x + 10)
     days = days_func(effective_limit)
 
@@ -402,8 +413,8 @@ def fetch_yfinance_klines(
             return []
 
     bars = _bars_from_yfinance_df(df)
-    if timeframe == "4H" and bars:
-        bars = _merge_every_n_sorted_bars(bars, 4)
+    if merge_factor > 1 and bars:
+        bars = _merge_every_n_sorted_bars(bars, merge_factor)
     logger.debug("yfinance returned %d bars for %s tf=%s", len(bars), yf_sym, timeframe)
     return bars
 
@@ -413,7 +424,7 @@ def fetch_yfinance_klines(
 # ---------------------------------------------------------------------------
 
 def _minute_period_str(timeframe: str) -> Optional[str]:
-    return {"1m": "1", "5m": "5", "15m": "15", "30m": "30", "1H": "60", "4H": "60"}.get(timeframe)
+    return {"1m": "1", "3m": "1", "5m": "5", "15m": "15", "30m": "30", "1H": "60", "4H": "60"}.get(timeframe)
 
 
 def _min_bar_window(timeframe: str, limit: int, before_time: Optional[int]) -> tuple[str, str]:
@@ -525,8 +536,9 @@ def fetch_akshare_minute_klines(
             return []
 
     bars = _bars_from_ak_min_df(df)
-    if timeframe == "4H" and bars:
-        bars = _merge_every_n_sorted_bars(bars, 4)
+    merge_factor = _MERGE_FACTOR_MAP.get(timeframe, 1)
+    if merge_factor > 1 and bars:
+        bars = _merge_every_n_sorted_bars(bars, merge_factor)
     return bars
 
 

--- a/backend_api_python/app/data_sources/base.py
+++ b/backend_api_python/app/data_sources/base.py
@@ -14,6 +14,7 @@ logger = get_logger(__name__)
 # K线周期映射（秒数）
 TIMEFRAME_SECONDS = {
     '1m': 60,
+    '3m': 180,
     '5m': 300,
     '15m': 900,
     '30m': 1800,

--- a/backend_api_python/app/data_sources/us_stock.py
+++ b/backend_api_python/app/data_sources/us_stock.py
@@ -22,6 +22,7 @@ class USStockDataSource(BaseDataSource):
     # yfinance 时间周期映射
     INTERVAL_MAP = {
         '1m': '1m',
+        '3m': '1m',
         '5m': '5m',
         '15m': '15m',
         '30m': '30m',
@@ -35,6 +36,7 @@ class USStockDataSource(BaseDataSource):
     # 美股每日约6.5交易小时，交易日/日历日 ≈ 5/7；乘1.5留余量
     DAYS_MAP = {
         '1m': lambda limit: min(7, max(1, (limit // 390) + 2)),
+        '3m': lambda limit: min(7, max(1, (limit // 130) + 2)),
         '5m': lambda limit: min(60, max(1, (limit // 78) + 2)),
         '15m': lambda limit: min(60, max(2, (limit // 26) + 3)),
         '30m': lambda limit: min(60, max(2, (limit // 13) + 3)),
@@ -42,6 +44,10 @@ class USStockDataSource(BaseDataSource):
         '4H': lambda limit: min(730, max(10, int(limit / 1.625 * 7 / 5 * 1.5) + 5)),
         '1D': lambda limit: min(3650, limit + 1),
         '1W': lambda limit: min(3650, (limit * 7) + 7)
+    }
+
+    MERGE_FACTOR_MAP = {
+        '3m': 3,
     }
     
     def __init__(self):
@@ -181,7 +187,9 @@ class USStockDataSource(BaseDataSource):
         try:
             interval = self.INTERVAL_MAP.get(timeframe, '1d')
             days_func = self.DAYS_MAP.get(timeframe, lambda x: x + 1)
-            days = days_func(limit)
+            merge_factor = self.MERGE_FACTOR_MAP.get(timeframe, 1)
+            effective_limit = limit * merge_factor
+            days = days_func(effective_limit)
             
             # 计算日期范围
             if before_time:
@@ -212,7 +220,9 @@ class USStockDataSource(BaseDataSource):
                             truncate=(after_time is None),
                         )
             else:
-                klines = self._convert_dataframe(df, limit)
+                klines = self._convert_dataframe(df, effective_limit)
+                if merge_factor > 1:
+                    klines = self._merge_every_n_sorted_bars(klines, merge_factor)
             
             # 过滤和限制
             klines = self.filter_and_limit(
@@ -252,7 +262,24 @@ class USStockDataSource(BaseDataSource):
         except Exception as e:
             logger.warning(f"yfinance fetch failed: {e}")
             return None
-    
+
+    def _merge_every_n_sorted_bars(self, bars: List[Dict[str, Any]], n: int) -> List[Dict[str, Any]]:
+        if n <= 1 or len(bars) < n:
+            return bars
+        bars = sorted(bars, key=lambda x: x['time'])
+        out = []
+        for i in range(0, len(bars) - len(bars) % n, n):
+            chunk = bars[i:i + n]
+            out.append({
+                'time': chunk[0]['time'],
+                'open': chunk[0]['open'],
+                'high': max(b['high'] for b in chunk),
+                'low': min(b['low'] for b in chunk),
+                'close': chunk[-1]['close'],
+                'volume': round(sum(b['volume'] for b in chunk), 2),
+            })
+        return out
+
     def _fetch_finnhub(
         self,
         symbol: str,

--- a/backend_api_python/tests/test_three_minute_timeframe.py
+++ b/backend_api_python/tests/test_three_minute_timeframe.py
@@ -1,0 +1,40 @@
+import sys
+from pathlib import Path
+
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(BACKEND_ROOT))
+
+from app.config.data_sources import CCXTConfig
+from app.data_sources import asia_stock_kline
+from app.data_sources.base import TIMEFRAME_SECONDS
+from app.data_sources.us_stock import USStockDataSource
+
+
+def test_three_minute_timeframe_is_registered_for_kline_sources():
+    assert TIMEFRAME_SECONDS["3m"] == 180
+    assert CCXTConfig.TIMEFRAME_MAP["3m"] == "3m"
+
+    assert USStockDataSource.INTERVAL_MAP["3m"] == "1m"
+    assert USStockDataSource.MERGE_FACTOR_MAP["3m"] == 3
+
+    assert asia_stock_kline._TD_INTERVAL_MAP["3m"] == "1min"
+    assert asia_stock_kline._YF_INTERVAL_MAP["3m"] == "1m"
+    assert asia_stock_kline._minute_period_str("3m") == "1"
+    assert asia_stock_kline._MERGE_FACTOR_MAP["3m"] == 3
+
+
+def test_three_minute_us_stock_bars_merge_one_minute_bars():
+    source = USStockDataSource()
+    bars = [
+        {"time": 60, "open": 10, "high": 11, "low": 9, "close": 10.5, "volume": 100},
+        {"time": 120, "open": 10.5, "high": 12, "low": 10, "close": 11, "volume": 150},
+        {"time": 180, "open": 11, "high": 11.5, "low": 10.8, "close": 11.2, "volume": 200},
+        {"time": 240, "open": 11.2, "high": 11.4, "low": 11, "close": 11.1, "volume": 50},
+    ]
+
+    merged = source._merge_every_n_sorted_bars(bars, 3)
+
+    assert merged == [
+        {"time": 60, "open": 10, "high": 12, "low": 9, "close": 11.2, "volume": 450}
+    ]


### PR DESCRIPTION
## Summary
- register `3m` in backend timeframe seconds and exchange timeframe config
- support 3-minute stock K-lines by fetching 1-minute bars and aggregating them for yfinance/AkShare-style providers
- add regression coverage for registration and US stock bar aggregation

## Validation
- `uv run --no-sync pytest backend_api_python/tests/test_three_minute_timeframe.py -q`
- `python -m py_compile backend_api_python/app/data_sources/base.py backend_api_python/app/config/data_sources.py backend_api_python/app/data_sources/asia_stock_kline.py backend_api_python/app/data_sources/us_stock.py backend_api_python/tests/test_three_minute_timeframe.py`
- `git diff --check`

Fixes #72