### PR TITLE
Security: gate broker routes + CORS allow-list; fix agent token crash

### DIFF
--- a/backend_api_python/app/__init__.py
+++ b/backend_api_python/app/__init__.py
@@ -2,6 +2,7 @@
 QuantDinger Python API - Flask application factory.
 """
 import math
+import os
 import logging
 import traceback
 
@@ -224,9 +225,21 @@ def create_app(config_name='default'):
     app.json = SafeJSONProvider(app)
 
     app.config['JSON_AS_ASCII'] = False
-    
-    CORS(app)
-    
+
+    # CORS — pin to specific origins instead of '*'. FRONTEND_URL accepts a
+    # comma-separated list (e.g. "http://localhost:8888,http://localhost:8000")
+    # so dev and prod frontends can both be allowed. Default covers the docker
+    # frontend port (8888) and the Vue dev server port (8000).
+    _cors_origins = [
+        o.strip() for o in os.getenv(
+            "FRONTEND_URL",
+            "http://localhost:8888,http://localhost:8000",
+        ).split(",")
+        if o.strip()
+    ]
+    CORS(app, origins=_cors_origins)
+    logger.info(f"CORS allowed origins: {_cors_origins}")
+
     setup_logger()
     
     # Initialize database and ensure admin user exists

--- a/backend_api_python/app/routes/agent_v1/_helpers.py
+++ b/backend_api_python/app/routes/agent_v1/_helpers.py
@@ -6,17 +6,22 @@ from typing import Any, Optional
 from flask import jsonify, request
 
 
-def envelope(data: Any, *, message: str = "ok", code: int = 0) -> tuple:
+def envelope(data: Any, *, message: str = "ok", code: int = 0, status: int = 200) -> tuple:
     """Standard agent-facing response envelope.
 
     Distinct from the legacy human envelope (`code: 1, msg, data`) so client
     code targeting `/api/agent/v1` can rely on a single, stable shape.
+
+    The HTTP status defaults to 200; pass ``status=202`` for async-queue
+    responses.  Always returns a (Response, status) tuple so callers must
+    NOT wrap the result in another tuple — that produces nested tuples
+    Flask cannot decode.
     """
     return jsonify({
         "code": code,
         "message": message,
         "data": data,
-    }), 200
+    }), status
 
 
 def error(code: int, message: str, *, details: Any = None, retriable: bool = False, http: int = 400):

--- a/backend_api_python/app/routes/agent_v1/admin.py
+++ b/backend_api_python/app/routes/agent_v1/admin.py
@@ -137,8 +137,16 @@ def issue_token():
                 paper_only, rate_limit, expires_at,
             ),
         )
-        row = cur.fetchone()
+        # NOTE: app.utils.db_postgres' PostgresCursor wrapper silently
+        # consumes the RETURNING row into its internal `_last_insert_id`
+        # attribute, so cur.fetchone() here returns None.  Re-fetch via
+        # SELECT on the unique token_hash to recover id + created_at.
         db.commit()
+        cur.execute(
+            "SELECT id, created_at FROM qd_agent_tokens WHERE token_hash = %s",
+            (token_hash,),
+        )
+        row = cur.fetchone()
         cur.close()
 
     return envelope({

--- a/backend_api_python/app/routes/agent_v1/backtests.py
+++ b/backend_api_python/app/routes/agent_v1/backtests.py
@@ -97,7 +97,7 @@ def create_backtest():
                 "job_id": existing["job_id"],
                 "status": existing["status"],
                 "duplicate": True,
-            }, message="idempotent replay"), 200
+            }, message="idempotent replay")
 
     payload = dict(body)
     payload["__user_id"] = current_user_id()
@@ -108,4 +108,4 @@ def create_backtest():
         request_payload=payload,
         runner=_run_backtest,
     )
-    return envelope(job, message="queued"), 202
+    return envelope(job, message="queued", status=202)

--- a/backend_api_python/app/routes/agent_v1/experiments.py
+++ b/backend_api_python/app/routes/agent_v1/experiments.py
@@ -44,7 +44,7 @@ def submit_pipeline():
                 "job_id": existing["job_id"],
                 "status": existing["status"],
                 "duplicate": True,
-            }, message="idempotent replay"), 200
+            }, message="idempotent replay")
 
     payload = dict(body)
     payload["__user_id"] = current_user_id()
@@ -59,7 +59,7 @@ def submit_pipeline():
         request_payload=payload,
         runner=_run,
     )
-    return envelope(job, message="queued"), 202
+    return envelope(job, message="queued", status=202)
 
 
 @agent_v1_bp.route("/experiments/structured-tune", methods=["POST"])
@@ -83,7 +83,7 @@ def submit_structured_tune():
         request_payload=payload,
         runner=_run,
     )
-    return envelope(job, message="queued"), 202
+    return envelope(job, message="queued", status=202)
 
 
 @agent_v1_bp.route("/experiments/ai-optimize", methods=["POST"])
@@ -118,4 +118,4 @@ def submit_ai_optimize():
         request_payload=payload,
         runner=_run,
     )
-    return envelope(job, message="queued"), 202
+    return envelope(job, message="queued", status=202)

--- a/backend_api_python/app/routes/agent_v1/quick_trade.py
+++ b/backend_api_python/app/routes/agent_v1/quick_trade.py
@@ -133,7 +133,7 @@ def place_order():
             return envelope({
                 "duplicate": True,
                 "previous": existing.get("result"),
-            }, message="idempotent replay"), 200
+            }, message="idempotent replay")
 
     # Live trading is hard-gated. Even with paper_only=false on the token, the
     # operator must enable AGENT_LIVE_TRADING_ENABLED to actually route to

--- a/backend_api_python/app/routes/ibkr.py
+++ b/backend_api_python/app/routes/ibkr.py
@@ -5,6 +5,7 @@ Standalone API endpoints for US stock trading.
 """
 
 from flask import Blueprint, request, jsonify
+from app.utils.auth import login_required
 
 from app.utils.logger import get_logger
 from app.services.ibkr_trading import IBKRClient, IBKRConfig
@@ -29,6 +30,7 @@ def _get_client() -> IBKRClient:
 # ==================== Connection Management ====================
 
 @ibkr_bp.route('/status', methods=['GET'])
+@login_required
 def get_status():
     """
     Get connection status.
@@ -50,6 +52,7 @@ def get_status():
 
 
 @ibkr_bp.route('/connect', methods=['POST'])
+@login_required
 def connect():
     """
     Connect to TWS / IB Gateway.
@@ -111,6 +114,7 @@ def connect():
 
 
 @ibkr_bp.route('/disconnect', methods=['POST'])
+@login_required
 def disconnect():
     """
     Disconnect from IBKR.
@@ -141,6 +145,7 @@ def disconnect():
 # ==================== Account Queries ====================
 
 @ibkr_bp.route('/account', methods=['GET'])
+@login_required
 def get_account():
     """
     Get account information.
@@ -168,6 +173,7 @@ def get_account():
 
 
 @ibkr_bp.route('/positions', methods=['GET'])
+@login_required
 def get_positions():
     """
     Get positions.
@@ -196,6 +202,7 @@ def get_positions():
 
 
 @ibkr_bp.route('/orders', methods=['GET'])
+@login_required
 def get_orders():
     """
     Get open orders.
@@ -226,6 +233,7 @@ def get_orders():
 # ==================== Trading ====================
 
 @ibkr_bp.route('/order', methods=['POST'])
+@login_required
 def place_order():
     """
     Place an order.
@@ -313,6 +321,7 @@ def place_order():
 
 
 @ibkr_bp.route('/order/<int:order_id>', methods=['DELETE'])
+@login_required
 def cancel_order(order_id: int):
     """
     Cancel an order.
@@ -351,6 +360,7 @@ def cancel_order(order_id: int):
 # ==================== Market Data ====================
 
 @ibkr_bp.route('/quote', methods=['GET'])
+@login_required
 def get_quote():
     """
     Get real-time quote.

--- a/backend_api_python/app/routes/mt5.py
+++ b/backend_api_python/app/routes/mt5.py
@@ -5,6 +5,7 @@ Provides REST API for MT5 trading operations.
 """
 
 from flask import Blueprint, request, jsonify
+from app.utils.auth import login_required
 
 from app.utils.logger import get_logger
 
@@ -46,6 +47,7 @@ def _get_client():
 # ==================== Connection Management ====================
 
 @mt5_bp.route("/status", methods=["GET"])
+@login_required
 def get_status():
     """Get MT5 connection status."""
     try:
@@ -65,6 +67,7 @@ def get_status():
 
 
 @mt5_bp.route("/connect", methods=["POST"])
+@login_required
 def connect():
     """
     Connect to MT5 terminal.
@@ -138,6 +141,7 @@ def connect():
 
 
 @mt5_bp.route("/disconnect", methods=["POST"])
+@login_required
 def disconnect():
     """Disconnect from MT5 terminal."""
     global _client
@@ -155,6 +159,7 @@ def disconnect():
 # ==================== Account Queries ====================
 
 @mt5_bp.route("/account", methods=["GET"])
+@login_required
 def get_account():
     """Get account information."""
     try:
@@ -170,6 +175,7 @@ def get_account():
 
 
 @mt5_bp.route("/positions", methods=["GET"])
+@login_required
 def get_positions():
     """Get open positions."""
     try:
@@ -186,6 +192,7 @@ def get_positions():
 
 
 @mt5_bp.route("/orders", methods=["GET"])
+@login_required
 def get_orders():
     """Get pending orders."""
     try:
@@ -202,6 +209,7 @@ def get_orders():
 
 
 @mt5_bp.route("/symbols", methods=["GET"])
+@login_required
 def get_symbols():
     """Get available symbols."""
     try:
@@ -220,6 +228,7 @@ def get_symbols():
 # ==================== Trading ====================
 
 @mt5_bp.route("/order", methods=["POST"])
+@login_required
 def place_order():
     """
     Place an order.
@@ -296,6 +305,7 @@ def place_order():
 
 
 @mt5_bp.route("/close", methods=["POST"])
+@login_required
 def close_position():
     """
     Close a position.
@@ -348,6 +358,7 @@ def close_position():
 
 
 @mt5_bp.route("/order/<int:ticket>", methods=["DELETE"])
+@login_required
 def cancel_order(ticket: int):
     """Cancel a pending order."""
     try:
@@ -368,6 +379,7 @@ def cancel_order(ticket: int):
 # ==================== Market Data ====================
 
 @mt5_bp.route("/quote", methods=["GET"])
+@login_required
 def get_quote():
     """
     Get real-time quote.

--- a/docs/agent/AGENT_QUICKSTART.md
+++ b/docs/agent/AGENT_QUICKSTART.md
@@ -99,7 +99,7 @@ curl -s -X POST http://localhost:8888/api/agent/v1/backtests \
   -H "Content-Type: application/json" \
   -H "Idempotency-Key: ma-cross-2024-q1-001" \
   -d '{
-        "code": "output = {\"signal\": df[\"close\"] > df[\"close\"].rolling(20).mean()}",
+        "code": "fast = SMA(close, 10)\nslow = SMA(close, 30)\ndf[\"buy\"]  = CROSSOVER(fast, slow).fillna(False).astype(bool)\ndf[\"sell\"] = CROSSUNDER(fast, slow).fillna(False).astype(bool)",
         "market": "Crypto",
         "symbol": "BTC/USDT",
         "timeframe": "1D",
@@ -119,6 +119,61 @@ When `status` becomes `succeeded`, the backtest result is in `result`.
 
 The `Idempotency-Key` header makes retries safe: the second call with the
 same key returns the original job instead of submitting a duplicate.
+
+### 4.1 The `code` parameter contract
+
+`code` is a **Python script** that the backend executes inside a sandbox.
+The script must mutate the pre-bound `df` DataFrame to add boolean signal
+columns. It is **not** a function, callable, or expression that returns
+signals — those shapes will fail validation in `_simulate_trading`.
+
+**Pre-bound names** in the exec environment:
+
+| Name | Type | Notes |
+|------|------|-------|
+| `df` | `pd.DataFrame` | Columns: `time, open, high, low, close, volume`. Mutate in place. |
+| `open`, `high`, `low`, `close`, `volume` | `pd.Series` | Convenience handles for the columns above |
+| `np`, `pd` | modules | Standard NumPy / pandas |
+| `params` | `dict` | Indicator params parsed from `# @param` comments + caller overrides |
+| `call_indicator(...)` | callable | Invoke another saved indicator from this script |
+| `SMA, EMA, RSI, MACD, BOLL, ATR, CROSSOVER, CROSSUNDER` | callables | Built-in technical helpers (see `app/services/backtest.py::_get_indicator_functions`) |
+
+**Required output** — the script must add **either** of these to `df`:
+
+| Style | Required columns | When to use |
+|-------|------------------|-------------|
+| 2-way (recommended) | `df['buy']`, `df['sell']` (boolean Series) | Most strategies — simple long-only or `trade_direction='both'` |
+| 4-way (advanced) | `df['open_long']`, `df['close_long']`, `df['open_short']`, `df['close_short']` (boolean Series) | When you need explicit control over each leg |
+
+Minimal working SMA crossover:
+
+```python
+fast = SMA(close, 10)
+slow = SMA(close, 30)
+df['buy']  = CROSSOVER(fast, slow).fillna(False).astype(bool)
+df['sell'] = CROSSUNDER(fast, slow).fillna(False).astype(bool)
+```
+
+Trend-pullback with RSI filter (parameterized):
+
+```python
+# @param fast_len int 20 Fast EMA length
+# @param slow_len int 50 Slow EMA length
+# @param rsi_floor float 45 Min RSI for long entry
+
+ema_fast = EMA(close, params['fast_len'])
+ema_slow = EMA(close, params['slow_len'])
+rsi = RSI(close, 14)
+
+raw_buy  = (ema_fast > ema_slow) & (rsi >= params['rsi_floor'])
+raw_sell = (ema_fast < ema_slow)
+
+df['buy']  = (raw_buy.fillna(False)  & (~raw_buy.shift(1).fillna(False))).astype(bool)
+df['sell'] = (raw_sell.fillna(False) & (~raw_sell.shift(1).fillna(False))).astype(bool)
+```
+
+See `docs/STRATEGY_DEV_GUIDE.md` for the full indicator-authoring guide,
+including TP/SL/trailing-stop hooks (`# @strategy ...` comments).
 
 ### 4.1 Stream partial results (SSE)
 


### PR DESCRIPTION
## Summary

- **Gate IBKR + MT5 broker routes with `@login_required`.** All 9 IBKR + 11 MT5 routes (status, connect, disconnect, account, positions, orders, order POST/DELETE, quote, symbols, close) currently respond to anonymous requests. This change makes them return `401` without a Bearer token.
- **Pin CORS to a configured allow-list.** Replace `CORS(app)` (which sends `Access-Control-Allow-Origin: *`) with origins read from `FRONTEND_URL` env (defaults to `localhost:8888,localhost:8000`). Live response now carries the specific origin instead of `*`.
- **Fix `POST /api/agent/v1/admin/tokens` 500 crash.** The `PostgresCursor` wrapper in `app/utils/db_postgres.py` (lines 330–336) silently consumes `RETURNING` rows into `_last_insert_id`, so `cur.fetchone()` afterwards returns `None`. Issuing an agent token panicked with `TypeError: 'NoneType' object is not subscriptable` at `admin.py:145`, with the row inserted but the plaintext lost. Patched locally with a `SELECT` on `token_hash` after `COMMIT`. A more general fix (stop the wrapper from consuming caller-supplied `RETURNING` clauses) is worth filing as a follow-up.

## Test plan

- [x] `POST /api/ibkr/connect` and `/api/mt5/connect` without a token return `401` (was `200` before)
- [x] `GET /api/ibkr/status` etc. with a valid Bearer return `200` / business response
- [x] CORS preflight from `http://localhost:8888` returns `Access-Control-Allow-Origin: http://localhost:8888` (specific origin, never `*`)
- [x] CORS preflight from a non-allowlisted origin does not get the header
- [x] `POST /api/agent/v1/admin/tokens` with a valid admin JWT returns `200` and the plaintext token
- [x] `GET /api/agent/v1/whoami` with that token echoes the configured scopes
- [x] `GET /api/agent/v1/markets` and `/markets/Crypto/symbols` with the token return real data
- [x] Existing tokens issued before the patch continue to validate (the bug only affected issuance, not validation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)