### PR TITLE
fix(polymarket): resolve URL slugs precisely, drop silent popular-market fallback

### DIFF
--- a/backend_api_python/app/data_sources/polymarket.py
+++ b/backend_api_python/app/data_sources/polymarket.py
@@ -1040,60 +1040,71 @@ class PolymarketDataSource:
     
     def _fetch_market_by_slug(self, slug: str) -> Optional[Dict]:
         """
-        直接通过slug查询市场（最高效的方式）
-        根据Polymarket API文档：https://docs.polymarket.com/market-data/fetching-markets
-        可以使用 /markets?slug=xxx 直接查询
+        通过slug精确查询单个市场。
+
+        Polymarket的 `polymarket.com/event/<slug>` URL中，<slug>可能是：
+          - 某个市场的slug（单市场事件常见，如Como Serie A）→ /markets?slug=xxx 命中
+          - 某个事件的slug（多市场事件，如MicroStrategy）→ /events?slug=xxx 命中，事件下有多个markets
+        因此必须同时尝试两个端点。返回 None 表示该slug在Polymarket上不存在，
+        调用方应直接报错，不要回退到模糊搜索。
         """
+        if not slug:
+            return None
+        slug_lower = slug.lower().strip()
+
         try:
-            # 方法1: 尝试通过markets端点直接查询slug
-            url = f"{self.gamma_api}/markets"
-            params = {"slug": slug, "limit": 10}
-            logger.info(f"Fetching market by slug from Gamma API: {url} with params: {params}")
-            response = self.session.get(url, params=params, timeout=10)
-            
+            # 1. 先用 /markets?slug=xxx —— 当slug就是market slug时命中
+            response = self.session.get(
+                f"{self.gamma_api}/markets",
+                params={"slug": slug, "limit": 10},
+                timeout=10,
+            )
             if response.status_code == 200:
                 data = response.json()
-                if isinstance(data, list) and len(data) > 0:
-                    # 解析返回的市场数据
-                    markets = self._parse_gamma_events(data)
-                    # 精确匹配slug
-                    for market in markets:
-                        market_slug = market.get("slug", "").lower()
-                        if market_slug == slug.lower() or slug.lower() in market_slug:
-                            logger.info(f"Found market by slug: {slug}")
-                            return market
-                    # 如果没有精确匹配，返回第一个
-                    if markets:
-                        logger.info(f"Found market by slug (fuzzy match): {slug}")
-                        return markets[0]
-                elif isinstance(data, dict):
-                    # 单个市场对象
-                    markets = self._parse_gamma_events([data])
-                    if markets:
-                        logger.info(f"Found market by slug: {slug}")
-                        return markets[0]
-            
-            # 方法2: 尝试通过events端点查询（events可能包含slug信息）
-            url = f"{self.gamma_api}/events"
-            params = {"active": "true", "closed": "false", "limit": 100}
-            response = self.session.get(url, params=params, timeout=10)
-            
+                raw_markets = data if isinstance(data, list) else [data] if isinstance(data, dict) and data else []
+                # /markets 返回的是 market 对象，_parse_gamma_events 会把"无markets字段但有question的对象"当作单市场事件处理
+                for raw in raw_markets:
+                    if (raw.get("slug") or "").lower() == slug_lower:
+                        parsed = self._parse_gamma_events([raw])
+                        if parsed:
+                            logger.info(f"Found market via /markets?slug={slug}")
+                            return parsed[0]
+            else:
+                logger.debug(f"/markets?slug={slug} returned status {response.status_code}")
+
+            # 2. 再用 /events?slug=xxx —— 当slug是event slug（含多市场事件）时命中
+            response = self.session.get(
+                f"{self.gamma_api}/events",
+                params={"slug": slug, "limit": 5},
+                timeout=10,
+            )
             if response.status_code == 200:
                 data = response.json()
                 events = data if isinstance(data, list) else (data.get("data", []) if isinstance(data, dict) else [])
-                
-                # 在返回的事件中查找匹配的slug
                 for event in events:
-                    event_slug = (event.get("slug") or "").lower()
-                    if event_slug == slug.lower() or slug.lower() in event_slug:
+                    if (event.get("slug") or "").lower() != slug_lower:
+                        continue
+                    sub_markets = event.get("markets") or []
+                    # 优先选slug与event slug匹配的子市场（通常是"主"市场），否则取第一个
+                    chosen = next(
+                        (m for m in sub_markets if (m.get("slug") or "").lower() == slug_lower),
+                        sub_markets[0] if sub_markets else None,
+                    )
+                    if chosen is None:
+                        # event 直接当成单市场来解析
                         parsed = self._parse_gamma_events([event])
-                        if parsed:
-                            logger.info(f"Found market by slug via events: {slug}")
-                            return parsed[0]
-            
-            logger.warning(f"Market with slug '{slug}' not found via direct query")
+                    else:
+                        # 把选中的market作为"event"传进去，让_parse_gamma_events把它当作单市场对象处理
+                        parsed = self._parse_gamma_events([chosen])
+                    if parsed:
+                        logger.info(f"Found market via /events?slug={slug} (event has {len(sub_markets)} markets)")
+                        return parsed[0]
+            else:
+                logger.debug(f"/events?slug={slug} returned status {response.status_code}")
+
+            logger.warning(f"Slug '{slug}' not found on Polymarket via /markets or /events")
             return None
-            
+
         except Exception as e:
             logger.error(f"Failed to fetch market by slug {slug}: {e}", exc_info=True)
             return None

--- a/backend_api_python/app/routes/polymarket.py
+++ b/backend_api_python/app/routes/polymarket.py
@@ -84,41 +84,46 @@ def analyze_polymarket():
                     slug = extracted
                 break
         
-        # 如果没有从URL提取到，尝试搜索市场
-        if not market_id and not slug:
-            # 尝试通过标题搜索
-            logger.info(f"Searching for market by title: {input_text[:100]}")
-            search_results = polymarket_source.search_markets(input_text, limit=5)
-            if search_results:
-                # 使用第一个搜索结果
-                market_id = search_results[0].get('market_id')
-                logger.info(f"Found market via search: {market_id}")
-        
-        if not market_id and not slug:
-            return jsonify({
-                "code": 0,
-                "msg": "Could not parse market ID or slug from input. Please provide a valid Polymarket URL or market title.",
-                "data": None
-            }), 400
-        
         # 2. 获取市场数据
+        # 注意：如果用户输入了URL，slug或market_id已经被精确提取，必须按它精确取，
+        # 不要回退到模糊搜索 —— 那会把无关的热门市场误当成用户要的市场返回。
+        market = None
         if market_id:
             market = polymarket_source.get_market_details(market_id)
         elif slug:
-            # 通过slug查找市场（需要先搜索）
-            search_results = polymarket_source.search_markets(slug, limit=10)
-            market = None
-            for result in search_results:
-                if result.get('slug') == slug or slug in (result.get('question') or ''):
-                    market = result
-                    market_id = result.get('market_id')
-                    break
-            
-            if not market and search_results:
-                # 使用第一个搜索结果
-                market = search_results[0]
+            market = polymarket_source.get_market_details(slug)
+            if market and not market_id:
                 market_id = market.get('market_id')
-        
+        else:
+            # 用户输入的不是URL，按标题做关键词搜索；只有"足够确信"才接受
+            logger.info(f"Searching for market by title: {input_text[:100]}")
+            search_results = polymarket_source.search_markets(input_text, limit=5)
+            input_lower = input_text.lower()
+            confident_match = next(
+                (r for r in search_results if input_lower in (r.get('question') or '').lower()
+                 or input_lower == (r.get('slug') or '').lower()),
+                None,
+            )
+            if confident_match:
+                market = confident_match
+                market_id = market.get('market_id')
+            elif search_results:
+                # 找到了模糊候选但不够精准 —— 让用户改用URL，避免分析错市场
+                return jsonify({
+                    "code": 0,
+                    "msg": "Multiple possible markets matched. Please paste the exact Polymarket URL.",
+                    "data": {
+                        "candidates": [
+                            {
+                                "market_id": r.get('market_id'),
+                                "question": r.get('question'),
+                                "polymarket_url": r.get('polymarket_url'),
+                            }
+                            for r in search_results[:5]
+                        ]
+                    },
+                }), 409
+
         if not market:
             return jsonify({
                 "code": 0,

--- a/backend_api_python/app/routes/polymarket.py
+++ b/backend_api_python/app/routes/polymarket.py
@@ -67,10 +67,12 @@ def analyze_polymarket():
         slug = None
         
         # 尝试从URL中提取
+        # `(?:/[a-z]{2}(?:-[A-Z]{2})?)?` 兼容Polymarket的语言前缀，例如 /zh/、/en/、/zh-CN/。
+        # `([^/?#]+)` 截到下一个 /、?、# 之前。
         url_patterns = [
-            r'polymarket\.com/event/([^/?]+)',
-            r'polymarket\.com/markets/(\d+)',
-            r'polymarket\.com/market/(\d+)',
+            r'polymarket\.com(?:/[a-z]{2}(?:-[A-Z]{2})?)?/event/([^/?#]+)',
+            r'polymarket\.com(?:/[a-z]{2}(?:-[A-Z]{2})?)?/markets/(\d+)',
+            r'polymarket\.com(?:/[a-z]{2}(?:-[A-Z]{2})?)?/market/(\d+)',
         ]
         
         for pattern in url_patterns:
@@ -94,6 +96,14 @@ def analyze_polymarket():
             market = polymarket_source.get_market_details(slug)
             if market and not market_id:
                 market_id = market.get('market_id')
+        elif 'polymarket.com' in input_text.lower():
+            # 看起来是个polymarket URL但正则没抓到 —— 不要回退到fuzzy title search
+            # （那会把整段URL当作关键词去打分，必然返回无关结果）
+            return jsonify({
+                "code": 0,
+                "msg": "Could not parse a market slug from this Polymarket URL. Please paste the URL directly from a market page (looks like https://polymarket.com/event/<slug>).",
+                "data": None
+            }), 400
         else:
             # 用户输入的不是URL，按标题做关键词搜索；只有"足够确信"才接受
             logger.info(f"Searching for market by title: {input_text[:100]}")

--- a/backend_api_python/tests/test_polymarket_slug_lookup.py
+++ b/backend_api_python/tests/test_polymarket_slug_lookup.py
@@ -1,0 +1,117 @@
+"""Regression tests for PolymarketDataSource._fetch_market_by_slug.
+
+These pin the behavior that fixes the bug where pasting different Polymarket
+event URLs always returned the same (popular but unrelated) market: the lookup
+must hit both /markets?slug=xxx and /events?slug=xxx, and must return None
+(not a fallback popular market) when neither endpoint matches.
+"""
+from app.data_sources.polymarket import PolymarketDataSource
+
+
+class _FakeResp:
+    def __init__(self, payload, status=200):
+        self._p = payload
+        self.status_code = status
+
+    def json(self):
+        return self._p
+
+
+def _record_session(handler):
+    """Build a fake session whose .get(url, params=..., timeout=...) delegates to handler."""
+    calls = []
+
+    class _FakeSession:
+        @staticmethod
+        def get(url, params=None, timeout=None):
+            calls.append((url, params or {}))
+            return handler(url, params or {})
+
+    return _FakeSession(), calls
+
+
+def test_slug_lookup_uses_markets_endpoint_first(monkeypatch):
+    """Single-market events (slug is a market slug) must resolve via /markets?slug= without ever hitting /events."""
+    src = PolymarketDataSource()
+
+    def handler(url, params):
+        if url.endswith("/markets") and params.get("slug") == "como-slug":
+            return _FakeResp([{"slug": "como-slug", "question": "Q?", "id": "123"}])
+        return _FakeResp([])
+
+    fake_session, calls = _record_session(handler)
+    monkeypatch.setattr(src, "session", fake_session)
+    monkeypatch.setattr(
+        src,
+        "_parse_gamma_events",
+        lambda lst: [{"market_id": "123", "question": "Q?", "slug": "como-slug"}],
+    )
+
+    result = src._fetch_market_by_slug("como-slug")
+
+    assert result is not None
+    assert result["market_id"] == "123"
+    assert result["slug"] == "como-slug"
+    # /events must NOT be queried when /markets already answered
+    assert not any(url.endswith("/events") for url, _ in calls)
+
+
+def test_slug_lookup_falls_back_to_events_for_multi_market_events(monkeypatch):
+    """Multi-market events (slug is an event slug, not a market slug) must resolve via /events?slug= and pick the sub-market whose slug equals the event slug."""
+    src = PolymarketDataSource()
+
+    def handler(url, params):
+        if url.endswith("/markets"):
+            return _FakeResp([])  # event slug is not a market slug → empty
+        if url.endswith("/events") and params.get("slug") == "ms-event":
+            return _FakeResp([
+                {
+                    "slug": "ms-event",
+                    "markets": [
+                        # the "primary" market shares the event slug
+                        {"slug": "ms-event", "question": "Primary?", "id": "100"},
+                        {"slug": "ms-other", "question": "Other?", "id": "101"},
+                    ],
+                }
+            ])
+        return _FakeResp([])
+
+    fake_session, calls = _record_session(handler)
+    monkeypatch.setattr(src, "session", fake_session)
+    # _parse_gamma_events is wrapped: it sees the chosen sub-market (with slug == event slug)
+    monkeypatch.setattr(
+        src,
+        "_parse_gamma_events",
+        lambda lst: [{"market_id": lst[0]["id"], "question": lst[0]["question"], "slug": lst[0]["slug"]}],
+    )
+
+    result = src._fetch_market_by_slug("ms-event")
+
+    assert result is not None
+    # must pick the sub-market matching the event slug, not the first arbitrary one
+    assert result["market_id"] == "100"
+    assert result["slug"] == "ms-event"
+    # both endpoints participated
+    urls = [u for u, _ in calls]
+    assert any(u.endswith("/markets") for u in urls)
+    assert any(u.endswith("/events") for u in urls)
+
+
+def test_slug_lookup_returns_none_when_neither_endpoint_finds_it(monkeypatch):
+    """No silent fallback: an unknown slug must return None so the route can 404, instead of substituting an unrelated popular market."""
+    src = PolymarketDataSource()
+
+    def handler(url, params):
+        return _FakeResp([])
+
+    fake_session, _ = _record_session(handler)
+    monkeypatch.setattr(src, "session", fake_session)
+    monkeypatch.setattr(src, "_parse_gamma_events", lambda lst: [])
+
+    assert src._fetch_market_by_slug("does-not-exist-12345") is None
+
+
+def test_slug_lookup_handles_empty_input():
+    """Defensive: empty slug must short-circuit to None."""
+    assert PolymarketDataSource()._fetch_market_by_slug("") is None
+    assert PolymarketDataSource()._fetch_market_by_slug(None) is None

--- a/backend_api_python/tests/test_polymarket_url_parsing.py
+++ b/backend_api_python/tests/test_polymarket_url_parsing.py
@@ -1,0 +1,75 @@
+"""Regression tests for the URL-parsing regex used by /api/polymarket/analyze.
+
+The original regex `polymarket\\.com/event/(...)` failed to match localized URLs
+like `polymarket.com/zh/event/...` that Polymarket serves when a browser is set
+to a non-English locale. The route then fell back to fuzzy title search using
+the entire URL as a "keyword", which scored unrelated markets and surfaced the
+wrong question (or, after the earlier fix, returned a 409 to the user).
+
+These tests pin the patterns directly so the regex can't regress without notice.
+"""
+import re
+
+# Mirror the patterns used by app/routes/polymarket.py — keep these in sync.
+URL_PATTERNS = [
+    r'polymarket\.com(?:/[a-z]{2}(?:-[A-Z]{2})?)?/event/([^/?#]+)',
+    r'polymarket\.com(?:/[a-z]{2}(?:-[A-Z]{2})?)?/markets/(\d+)',
+    r'polymarket\.com(?:/[a-z]{2}(?:-[A-Z]{2})?)?/market/(\d+)',
+]
+
+
+def _extract(text):
+    for pattern in URL_PATTERNS:
+        m = re.search(pattern, text)
+        if m:
+            return m.group(1)
+    return None
+
+
+def test_plain_event_url():
+    assert _extract("https://polymarket.com/event/will-como-finish-in-the-top-4") == "will-como-finish-in-the-top-4"
+
+
+def test_event_url_with_locale_zh():
+    """Polymarket inserts /zh/ when the user's browser is set to Chinese — must be recognized."""
+    assert _extract("https://polymarket.com/zh/event/us-x-iran-permanent-peace-deal-by") == "us-x-iran-permanent-peace-deal-by"
+
+
+def test_event_url_with_locale_en():
+    assert _extract("https://polymarket.com/en/event/kraken-ipo-in-2025") == "kraken-ipo-in-2025"
+
+
+def test_event_url_with_full_locale_code():
+    """Some localized links use BCP47-style codes like zh-CN."""
+    assert _extract("https://polymarket.com/zh-CN/event/microstrategy-sell-any-bitcoin-in-2025") == "microstrategy-sell-any-bitcoin-in-2025"
+
+
+def test_event_url_with_query_string():
+    """Trackers/tids etc. after the slug must not bleed into the captured slug."""
+    assert _extract("https://polymarket.com/event/kraken-ipo-in-2025?tid=abc123") == "kraken-ipo-in-2025"
+
+
+def test_event_url_with_trailing_fragment():
+    assert _extract("https://polymarket.com/event/kraken-ipo-in-2025#comments") == "kraken-ipo-in-2025"
+
+
+def test_markets_numeric_id():
+    assert _extract("https://polymarket.com/markets/123456") == "123456"
+
+
+def test_markets_numeric_id_with_locale():
+    assert _extract("https://polymarket.com/zh/markets/123456") == "123456"
+
+
+def test_singular_market_path():
+    assert _extract("https://polymarket.com/market/789") == "789"
+
+
+def test_non_polymarket_url_returns_none():
+    assert _extract("https://example.com/event/something") is None
+
+
+def test_three_letter_segment_is_not_treated_as_locale():
+    """Polymarket only uses ISO 639-1 two-letter locale codes. Three-letter segments aren't real paths,
+    so the regex refuses them rather than guessing — caller will see a clean 400."""
+    assert _extract("https://polymarket.com/eng/event/xxx") is None


### PR DESCRIPTION
## Summary

Pasting different Polymarket event URLs into the AI-analysis modal always produced the same (low-volume, unrelated) market — most users saw the small \"Will Como finish in the top 4...\" market regardless of input. This PR makes URL-driven slug lookups precise and removes the silent fallback that masked the bug.

## Root cause

Two layers were broken:

1. **`PolymarketDataSource._fetch_market_by_slug`** only queried `/markets?slug=xxx`. That works when the URL slug is a *market* slug (single-market events like Como). For multi-market events (MicroStrategy, Kraken IPO, …), the URL slug is an *event* slug and `/markets?slug=` returns 0. The existing fallback then fetched the top-100 active events **without** using the slug filter and iterated — which almost never matched the user's input.

2. **`/api/polymarket/analyze` route's slug branch** called `search_markets(slug)` (fuzzy keyword scoring over ~100 events) and, when no exact match was found, silently used `search_results[0]` — the highest-volume market sharing any generic word (\"2025\", \"season\", \"top\") with the input slug. That is why one tiny ~\$1.6K market kept being returned.

Verified empirically with the real Gamma API:

| Slug | `/markets?slug` | `/events?slug` |
|---|---|---|
| `will-como-finish-in-the-top-4-in-the-2025-26-serie-a-season` | 1 result | 0 |
| `microstrategy-sell-any-bitcoin-in-2025` | 0 | 1 event w/ 5 markets |
| `kraken-ipo-in-2025` | 0 | 1 event w/ 4 markets |
| `totally-fake-event-slug-12345` | 0 | 0 |

We must consult **both** endpoints, and we must **not** fall back to a popular market when neither matches.

## Changes

- **`backend_api_python/app/data_sources/polymarket.py`** — rewrite `_fetch_market_by_slug` to:
  - query `/markets?slug=xxx` first (covers single-market events);
  - then `/events?slug=xxx` (covers multi-market events), and pick the sub-market whose slug equals the event slug (the \"primary\" one);
  - return `None` when neither endpoint matches. Dropped the previous top-100 events scan.
- **`backend_api_python/app/routes/polymarket.py`** — in the analyze handler:
  - when a slug or numeric `market_id` is extracted from the URL, call `get_market_details(...)` directly and 404 cleanly if absent (no fuzzy fallback);
  - when the user typed a plain title (no URL), only accept a search result when the input is a literal substring of `question` or equals `slug`; otherwise return `409` with up to 5 candidates so the UI can ask the user to paste the exact URL.
- **`backend_api_python/tests/test_polymarket_slug_lookup.py`** (new) — pins the contract: `/markets` is consulted first, `/events` is the fallback, the right sub-market is chosen for multi-market events, unknown slugs return `None`, and empty inputs short-circuit.

No API contract changes for successful responses. The new `409` is only emitted on the non-URL title-search path when there's no high-confidence match — previously this path silently substituted an unrelated market.

## Changes

- Rewrote `_fetch_market_by_slug` to query both Gamma API slug endpoints with correct semantics.
- Removed the silent \"use first fuzzy search result\" fallback from the `/api/polymarket/analyze` slug branch.
- Tightened the title-search branch to require a literal substring match.
- Added regression tests for the slug-lookup logic.

## Test plan

- [x] Smoke-tested `_fetch_market_by_slug` against the real Gamma API for Como (single-market), MicroStrategy + Kraken IPO (multi-market) and a nonsense slug — all return the expected market or `None`.
- [x] New pytest `test_polymarket_slug_lookup.py` runs cleanly (4/4 pass) under a stripped harness without Flask installed; will run identically under `pytest` once dependencies are present.
- [x] `python -m compileall app/` clean — same syntax-check CI workflow as `basic-ci.yml`.
- [ ] To verify locally with `docker compose up -d --build`: open the Polymarket analysis modal, paste two distinct event URLs (one single-market like Como, one multi-market like Kraken IPO), confirm the returned question matches the pasted URL each time. Paste a fake URL and confirm a clean 404 instead of an unrelated result.

## Screenshots

N/A — backend-only fix; the frontend modal renders whatever the API returns, so the fix is visible just by the modal now showing the question that matches the pasted URL.

## Backward compatibility

- Successful response shape is unchanged.
- New `409 Multiple possible markets matched` is only returned on the title-search path when no result is a confident match. The previous behavior on that path was to silently pick a wrong market, so any client relying on that was already broken.