### PR TITLE
fix(crypto): resample on backend when exchange lacks the requested timeframe

### DIFF
--- a/backend_api_python/app/data_sources/crypto.py
+++ b/backend_api_python/app/data_sources/crypto.py
@@ -20,7 +20,20 @@ class CryptoDataSource(BaseDataSource):
     
     # 时间周期映射
     TIMEFRAME_MAP = CCXTConfig.TIMEFRAME_MAP
-    
+
+    # 当某个交易所原生不支持某个CCXT周期时，从更细的granularity拉数据后聚合。
+    # 例如Coinbase Advanced Trade只暴露1m/5m/15m/30m/1h/2h/6h/1d，没有3m/4h/1w，
+    # 这里给出每个缺失目标对应的"源周期 + 倍数"候选（按优先顺序）。
+    _RESAMPLE_CANDIDATES: Dict[str, List[Tuple[str, int]]] = {
+        '3m': [('1m', 3)],
+        '4h': [('2h', 2), ('1h', 4)],
+        '1w': [('1d', 7)],
+    }
+
+    # CCXT单次fetch_ohlcv请求上限（Coinbase REST是300，多数交易所也在300附近）。
+    # 聚合路径fetch源数据时按这个值兜底，避免请求被服务端截断。
+    _SINGLE_FETCH_HARD_CAP = 300
+
     # 常见的报价货币列表（按优先级排序）
     COMMON_QUOTES = ['USDT', 'USD', 'BTC', 'ETH', 'BUSD', 'USDC', 'BNB', 'EUR', 'GBP']
     
@@ -242,24 +255,65 @@ class CryptoDataSource(BaseDataSource):
         
         try:
             ccxt_timeframe = self.TIMEFRAME_MAP.get(timeframe, '1d')
-            
+
+            # 如果当前交易所原生不支持这个周期（典型例子：Coinbase 没有 1w/4h/3m），
+            # 改为从更细的granularity拉数据，再在服务端聚合成目标周期。这样1W/4H在
+            # 不支持的交易所上仍可使用，无需前端改动。
+            resample_bucket = 1
+            fetch_ccxt_timeframe = ccxt_timeframe
+            fetch_qd_timeframe = timeframe
+            fetch_limit = limit
+
+            exchange_timeframes = getattr(self.exchange, 'timeframes', None) or {}
+            if exchange_timeframes and ccxt_timeframe not in exchange_timeframes:
+                picked = self._pick_resample_source(ccxt_timeframe, exchange_timeframes)
+                if picked is None:
+                    logger.warning(
+                        f"Exchange '{self.exchange.id}' cannot serve timeframe '{ccxt_timeframe}' "
+                        f"and no finer supported granularity is available for resampling. "
+                        f"Supported: {sorted(exchange_timeframes.keys())}"
+                    )
+                    return []
+                source_ccxt_tf, bucket = picked
+                fetch_ccxt_timeframe = source_ccxt_tf
+                fetch_qd_timeframe = self._ccxt_to_qd_timeframe(source_ccxt_tf, timeframe)
+                resample_bucket = bucket
+                # 单次fetch_ohlcv受交易所上限制约（Coinbase=300），超出会被截断；
+                # 在这之内取尽量多的源candle以填满请求的聚合数。
+                fetch_limit = min(limit * bucket, self._SINGLE_FETCH_HARD_CAP)
+                logger.info(
+                    f"Exchange '{self.exchange.id}' has no native '{ccxt_timeframe}' "
+                    f"timeframe; fetching '{source_ccxt_tf}' x{bucket} candles "
+                    f"({fetch_limit}) and resampling to '{ccxt_timeframe}'"
+                )
+
             # 使用统一的符号规范化方法
             symbol_pair = self._normalize_symbol_for_exchange(symbol)
-            
+
             if not symbol_pair:
                 logger.warning(f"Failed to normalize symbol for K-line: {symbol}")
                 return []
-            
+
             # logger.info(f"获取加密货币K线: {symbol_pair}, 周期: {ccxt_timeframe}, 条数: {limit}")
-            
+
             ohlcv = self._fetch_ohlcv(
-                symbol_pair, ccxt_timeframe, limit, before_time, timeframe, after_time
+                symbol_pair, fetch_ccxt_timeframe, fetch_limit,
+                before_time, fetch_qd_timeframe, after_time,
             )
-            
+
             if not ohlcv:
                 logger.warning(f"CCXT returned no K-lines: {symbol_pair}")
                 return []
-            
+
+            if resample_bucket > 1:
+                ohlcv = self._resample_ohlcv(ohlcv, resample_bucket)
+                if not ohlcv:
+                    logger.warning(
+                        f"Resampling produced no candles for {symbol_pair} "
+                        f"(bucket={resample_bucket}, source len was less than one bucket)"
+                    )
+                    return []
+
             # 转换数据格式
             for candle in ohlcv:
                 if len(candle) < 6:
@@ -304,7 +358,58 @@ class CryptoDataSource(BaseDataSource):
             logger.error(traceback.format_exc())
         
         return klines
-    
+
+    @classmethod
+    def _pick_resample_source(
+        cls,
+        target_ccxt_timeframe: str,
+        exchange_timeframes: Dict[str, Any],
+    ) -> Optional[Tuple[str, int]]:
+        """Pick the finest supported source timeframe to resample into `target_ccxt_timeframe`.
+
+        Returns (source_ccxt_timeframe, bucket_size) or None if no candidate is supported.
+        """
+        for source, bucket in cls._RESAMPLE_CANDIDATES.get(target_ccxt_timeframe, []):
+            if source in exchange_timeframes:
+                return source, bucket
+        return None
+
+    @staticmethod
+    def _resample_ohlcv(ohlcv: List[List[Any]], bucket_size: int) -> List[List[Any]]:
+        """Aggregate every `bucket_size` consecutive CCXT OHLCV rows into one larger candle.
+
+        Each input row is [ts_ms, open, high, low, close, volume]. Output preserves the
+        first row's timestamp and open, takes max(high)/min(low), the last row's close,
+        and sums volume. The trailing partial bucket is dropped so every returned candle
+        represents `bucket_size` source candles.
+        """
+        if bucket_size <= 1 or not ohlcv:
+            return list(ohlcv or [])
+        out: List[List[Any]] = []
+        for i in range(0, len(ohlcv), bucket_size):
+            chunk = ohlcv[i:i + bucket_size]
+            if len(chunk) < bucket_size:
+                break  # drop incomplete trailing bucket
+            out.append([
+                chunk[0][0],
+                chunk[0][1],
+                max(c[2] for c in chunk),
+                min(c[3] for c in chunk),
+                chunk[-1][4],
+                sum(c[5] for c in chunk),
+            ])
+        return out
+
+    @classmethod
+    def _ccxt_to_qd_timeframe(cls, ccxt_tf: str, fallback: str) -> str:
+        """Reverse the TIMEFRAME_MAP — e.g. '1d' → '1D'. Used so downstream helpers
+        that take the QuantDinger-style timeframe string get a consistent value when
+        we fetch a different granularity than originally requested."""
+        for qd, ccxt_value in cls.TIMEFRAME_MAP.items():
+            if ccxt_value == ccxt_tf:
+                return qd
+        return fallback
+
     def _fetch_ohlcv(
         self,
         symbol_pair: str,

--- a/backend_api_python/tests/test_crypto_timeframe_resample.py
+++ b/backend_api_python/tests/test_crypto_timeframe_resample.py
@@ -1,0 +1,117 @@
+"""Regression tests for CryptoDataSource timeframe resampling.
+
+Background: Coinbase Advanced Trade exposes only {1m, 5m, 15m, 30m, 1h, 2h, 6h, 1d}
+via CCXT — it has no 1w, 4h, or 3m. Before this fix, requesting timeframe=1W on a
+Coinbase-backed deployment hit `parsing field "granularity": "1w" is not a valid value`
+and the indicator IDE chart showed "No data found".
+
+These tests pin the two helpers that make the resample work, without needing a live
+exchange or the full data source __init__:
+  - `_pick_resample_source` chooses a finer supported granularity + bucket size
+  - `_resample_ohlcv` aggregates source candles into target-period candles correctly
+"""
+from app.data_sources.crypto import CryptoDataSource
+
+
+# --- _pick_resample_source -------------------------------------------------
+
+COINBASE_LIKE = {'1m': 1, '5m': 1, '15m': 1, '30m': 1, '1h': 1, '2h': 1, '6h': 1, '1d': 1}
+BINANCE_LIKE = {'1m': 1, '3m': 1, '5m': 1, '15m': 1, '30m': 1, '1h': 1, '2h': 1, '4h': 1, '6h': 1, '12h': 1, '1d': 1, '1w': 1}
+
+
+def test_pick_source_for_1w_on_coinbase_uses_1d_x7():
+    assert CryptoDataSource._pick_resample_source('1w', COINBASE_LIKE) == ('1d', 7)
+
+
+def test_pick_source_for_4h_on_coinbase_prefers_2h_over_1h():
+    # 2h exists on coinbase and gives a smaller bucket (fewer requested candles), so prefer it.
+    assert CryptoDataSource._pick_resample_source('4h', COINBASE_LIKE) == ('2h', 2)
+
+
+def test_pick_source_for_4h_falls_back_to_1h_when_2h_missing():
+    only_1h = {k: 1 for k in COINBASE_LIKE if k != '2h'}
+    assert CryptoDataSource._pick_resample_source('4h', only_1h) == ('1h', 4)
+
+
+def test_pick_source_for_3m_on_coinbase_uses_1m_x3():
+    assert CryptoDataSource._pick_resample_source('3m', COINBASE_LIKE) == ('1m', 3)
+
+
+def test_pick_source_returns_none_when_no_supported_finer_granularity():
+    # Made-up exchange with only daily resolution can't resample to 1w (well it could,
+    # 1d→1w x7 needs 1d), but it can't resample to 4h. Verify the None-on-miss branch.
+    only_daily = {'1d': 1}
+    assert CryptoDataSource._pick_resample_source('4h', only_daily) is None
+
+
+def test_pick_source_returns_none_for_unknown_target_timeframe():
+    assert CryptoDataSource._pick_resample_source('99x', COINBASE_LIKE) is None
+
+
+# --- _resample_ohlcv -------------------------------------------------------
+
+def _candle(ts_ms, o, h, l, c, v):
+    return [ts_ms, o, h, l, c, v]
+
+
+def test_resample_aggregates_OHLCV_correctly():
+    # 7 daily candles → 1 weekly candle
+    daily = [
+        _candle(1000, 100, 110,  95, 105, 10),
+        _candle(2000, 105, 120, 100, 115, 12),
+        _candle(3000, 115, 125, 110, 118,  8),
+        _candle(4000, 118, 130, 112, 122, 15),
+        _candle(5000, 122, 128, 115, 117, 11),
+        _candle(6000, 117, 119, 105, 108,  9),
+        _candle(7000, 108, 114,  98, 102, 13),
+    ]
+    out = CryptoDataSource._resample_ohlcv(daily, 7)
+    assert len(out) == 1
+    [ts, op, hi, lo, cl, vol] = out[0]
+    assert ts == 1000          # bucket timestamp = first candle's
+    assert op == 100           # bucket open = first candle's open
+    assert hi == 130           # max high across the bucket
+    assert lo == 95            # min low across the bucket
+    assert cl == 102           # close = last candle's close
+    assert vol == 10+12+8+15+11+9+13
+
+
+def test_resample_drops_incomplete_trailing_bucket():
+    # 10 daily candles, bucket=7 → 1 full bucket, 3 trailing dropped
+    daily = [_candle(1000 * (i + 1), 100, 110, 90, 105, 1) for i in range(10)]
+    out = CryptoDataSource._resample_ohlcv(daily, 7)
+    assert len(out) == 1
+    assert out[0][0] == 1000  # first bucket's start
+
+
+def test_resample_two_full_buckets():
+    daily = [_candle(1000 * (i + 1), 100, 110, 90, 105, 2) for i in range(14)]
+    out = CryptoDataSource._resample_ohlcv(daily, 7)
+    assert len(out) == 2
+    assert out[0][0] == 1000   # first bucket starts at first candle
+    assert out[1][0] == 8000   # second bucket starts at 8th candle
+    assert out[0][5] == 14     # volume sum = 7 * 2
+    assert out[1][5] == 14
+
+
+def test_resample_bucket_size_one_is_passthrough():
+    daily = [_candle(1000, 100, 110, 90, 105, 1)]
+    assert CryptoDataSource._resample_ohlcv(daily, 1) == daily
+
+
+def test_resample_empty_returns_empty():
+    assert CryptoDataSource._resample_ohlcv([], 7) == []
+
+
+# --- _ccxt_to_qd_timeframe -------------------------------------------------
+
+def test_ccxt_to_qd_timeframe_inverts_known_mappings():
+    # The TIMEFRAME_MAP maps QD '1D' → ccxt '1d', '1W' → '1w', '1H' → '1h'.
+    # The reverse helper must round-trip these for the resample-path bookkeeping.
+    assert CryptoDataSource._ccxt_to_qd_timeframe('1d', fallback='1W') == '1D'
+    assert CryptoDataSource._ccxt_to_qd_timeframe('1h', fallback='4H') == '1H'
+    assert CryptoDataSource._ccxt_to_qd_timeframe('1m', fallback='1m') == '1m'
+
+
+def test_ccxt_to_qd_timeframe_returns_fallback_for_unknown():
+    assert CryptoDataSource._ccxt_to_qd_timeframe('totally-fake', fallback='1W') == '1W'


### PR DESCRIPTION
## Summary

On a Coinbase-backed deployment (which is the only practical CCXT exchange for users in regions where Binance returns HTTP 451), the indicator IDE chart shows **"数据加载失败: No data found"** for BTC/USDT on the **1W**, **4H** and **3m** timeframes.

Coinbase Advanced Trade exposes only `{1m, 5m, 15m, 30m, 1h, 2h, 6h, 1d}` via CCXT, so `fetch_ohlcv(..., '1w', ...)` fails with `parsing field "granularity": "1w" is not a valid value` — the route still returns 200 but with an empty array.

This PR makes the data source resample on the backend when the configured exchange doesn't natively support the requested timeframe.

## How

- New class constant `_RESAMPLE_CANDIDATES` declares per-target source→bucket preferences:
  - `3m` → `1m × 3`
  - `4h` → prefer `2h × 2`, else `1h × 4`
  - `1w` → `1d × 7`
- `_pick_resample_source(target, exchange.timeframes)` returns the first supported candidate, or `None` so the caller can log + return `[]` cleanly instead of hitting the upstream 422.
- `_resample_ohlcv(ohlcv, bucket)` aggregates source candles: `open = first.open`, `high = max`, `low = min`, `close = last.close`, `volume = sum`, timestamp = first candle's. Trailing partial bucket is dropped so every returned candle represents a full period.
- `_ccxt_to_qd_timeframe` inverts `CCXTConfig.TIMEFRAME_MAP` (e.g. `'1d' → '1D'`) so downstream functions in `_fetch_ohlcv` that take the QuantDinger-style timeframe string still see a consistent value when we fetch a different granularity than originally requested.
- `get_kline` enters the resample path only when `ccxt_timeframe not in self.exchange.timeframes`; on supported timeframes the call path is unchanged. Fetch limit is capped at 300 (CCXT/Coinbase single-call max) to avoid silent truncation; for `1W` this yields ~42 weekly candles per request, sufficient for chart display.

## Changes

- `backend_api_python/app/data_sources/crypto.py` — add resample helpers, integrate into `get_kline`.
- `backend_api_python/tests/test_crypto_timeframe_resample.py` (new) — 13 unit tests for the helpers.

## Test plan

- [x] Verified the bug: `GET /api/indicator/kline?market=Crypto&symbol=BTC/USDT&timeframe=1W&limit=500` returns 55 bytes (`{"data":[],...}`) on `main`. Backend log: `CCXT fallback method also failed: coinbase {"error":"unknown","error_details":"parsing field \"granularity\": \"1w\" is not a valid value"}`.
- [x] 13/13 helper unit tests pass (`tests/test_crypto_timeframe_resample.py`): timeframe selection (Coinbase 1W → 1d×7, 4H → 2h×2 preferred, 4H fallback 1h×4, 3m → 1m×3, no candidate, unknown target), OHLCV aggregation math (full bucket, multiple buckets, drop trailing partial, bucket=1 passthrough, empty input), and TIMEFRAME_MAP inversion.
- [ ] To verify in Docker: rebuild backend, open indicator IDE → BTC/USDT → 1W; chart renders. Same for 4H. Other timeframes unchanged.

## Backward compatibility

- On exchanges that already support the requested timeframe (e.g. Binance has native `1w`), the resample path isn't entered — behavior is unchanged.
- Returned candle shape is unchanged (same `format_kline` output).
- For requests that previously returned `[]` due to the 422, they now return aggregated candles — strictly better, and the response envelope is the same.