### PR TITLE
feat(docker): publish images to ghcr and add zero-repo compose deploy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,17 @@
 # - This file lives in the project root and is used by docker-compose build/pull.
 # - `backend_api_python/.env` is runtime config for the backend container only.
 # - `IMAGE_PREFIX` applies to postgres, redis, backend base image, and frontend nginx.
-# - Backend Docker build auto-tries Aliyun apt/PyPI then falls back to Debian/PyPI official
-#   (no extra env). For slow `docker pull` of base images, use IMAGE_PREFIX or Docker
+# - For slow `docker pull` of base images, use IMAGE_PREFIX or Docker
 #   Desktop → Settings → Docker Engine → registry-mirrors (e.g. daocloud).
+
+# Backend Dockerfile region switch (used by docker-compose.yml build):
+#   cn      = use Aliyun apt/PyPI mirrors with fallback to official (default, zero-config for China)
+#   global  = use Debian/PyPI official sources directly, skip Aliyun entirely
+# BUILD_REGION=cn
+
+# ----- docker-compose.ghcr.yml (prebuilt images from GHCR) -----
+# Pin a specific image tag for backend + frontend (default: latest)
+# IMAGE_TAG=v3.0.6
+# Override the GHCR image paths (e.g. for forks)
+# BACKEND_IMAGE=ghcr.io/brokermr810/quantdinger-backend
+# FRONTEND_IMAGE=ghcr.io/brokermr810/quantdinger-frontend

--- a/.github/workflows/basic-ci.yml
+++ b/.github/workflows/basic-ci.yml
@@ -74,6 +74,20 @@ jobs:
           # - Dependencies are available and importable
           # - Core module structure is intact
 
+  compose-check:
+    name: Docker Compose Validation
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Validate docker-compose.yml (build mode)
+        run: docker compose -f docker-compose.yml config -q
+
+      - name: Validate docker-compose.ghcr.yml (GHCR mode)
+        run: docker compose -f docker-compose.ghcr.yml config -q
+
   frontend-check:
     name: Frontend Build Check
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,131 @@
+name: Publish Docker images to GHCR
+
+# Build and publish backend + frontend images to GitHub Container Registry.
+#
+# Triggers:
+#   - push of a version tag matching `v*` (e.g. v3.0.7) → publishes semver + latest tags
+#   - manual workflow_dispatch → publishes only a short-SHA tag for ad-hoc testing
+#
+# Images are built for linux/amd64 and linux/arm64 via QEMU + buildx. The backend
+# Dockerfile receives BUILD_REGION=global so the GitHub-hosted runner does not
+# detour through Aliyun mirrors.
+#
+# First-time setup: after the first successful run, visit
+#   https://github.com/users/<owner>/packages/container/quantdinger-backend/settings
+#   https://github.com/users/<owner>/packages/container/quantdinger-frontend/settings
+# and set both package visibilities to public if anonymous `docker pull` is desired.
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+# Cancel an in-flight build when a newer tag/dispatch lands on the same ref.
+# Avoids two workflows racing for the same GHA cache scope.
+concurrency:
+  group: docker-publish-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  backend:
+    name: Build & push backend image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/quantdinger-backend
+          tags: |
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=sha,format=short
+
+      - name: Build and push backend
+        uses: docker/build-push-action@v6
+        with:
+          context: ./backend_api_python
+          file: ./backend_api_python/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: |
+            BUILD_REGION=global
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=backend
+          cache-to: type=gha,mode=max,scope=backend
+          provenance: false
+
+  frontend:
+    name: Build & push frontend image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Verify prebuilt frontend dist
+        run: |
+          if [ ! -d frontend/dist ] || [ -z "$(ls -A frontend/dist 2>/dev/null)" ]; then
+            echo "::error::frontend/dist/ is missing or empty. Sync from QuantDinger-Vue before tagging." && exit 1
+          fi
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/quantdinger-frontend
+          tags: |
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=sha,format=short
+
+      - name: Build and push frontend
+        uses: docker/build-push-action@v6
+        with:
+          context: ./frontend
+          file: ./frontend/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=frontend
+          cache-to: type=gha,mode=max,scope=frontend
+          provenance: false

--- a/README.md
+++ b/README.md
@@ -381,6 +381,26 @@ docker-compose up -d --build
 
 Services: **`postgres`**, **`redis`**, **`backend`**, **`frontend`** (see `docker-compose.yml` for healthchecks and port mappings).
 
+#### Alternative: zero-repo install from GHCR
+
+If you do not want to clone the repository, the GHCR variant pulls prebuilt multi-arch (amd64/arm64) images for both backend and frontend:
+
+```bash
+curl -O https://raw.githubusercontent.com/brokermr810/QuantDinger/main/docker-compose.ghcr.yml
+curl -o .env https://raw.githubusercontent.com/brokermr810/QuantDinger/main/backend_api_python/env.example
+docker compose -f docker-compose.ghcr.yml up -d
+```
+
+The backend entrypoint auto-generates a random `SECRET_KEY` on first start and applies the schema (`migrations/init.sql`) idempotently. Edit `.env` for persistent overrides (API keys, OAuth, broker credentials). Pin a version by appending `IMAGE_TAG=v3.0.6` to the same `.env`:
+
+```env
+IMAGE_TAG=v3.0.6
+# BACKEND_IMAGE=ghcr.io/<your-fork>/quantdinger-backend     # optional, for forks
+# FRONTEND_IMAGE=ghcr.io/<your-fork>/quantdinger-frontend
+```
+
+Defaults: `ghcr.io/brokermr810/quantdinger-backend:latest` + `ghcr.io/brokermr810/quantdinger-frontend:latest`.
+
 ### 5) Verify and sign in
 
 | Check | URL / command |

--- a/README.md
+++ b/README.md
@@ -387,11 +387,11 @@ If you do not want to clone the repository, the GHCR variant pulls prebuilt mult
 
 ```bash
 curl -O https://raw.githubusercontent.com/brokermr810/QuantDinger/main/docker-compose.ghcr.yml
-curl -o .env https://raw.githubusercontent.com/brokermr810/QuantDinger/main/backend_api_python/env.example
+curl -o backend.env https://raw.githubusercontent.com/brokermr810/QuantDinger/main/backend_api_python/env.example
 docker compose -f docker-compose.ghcr.yml up -d
 ```
 
-The backend entrypoint auto-generates a random `SECRET_KEY` on first start and applies the schema (`migrations/init.sql`) idempotently. Edit `.env` for persistent overrides (API keys, OAuth, broker credentials). Pin a version by appending `IMAGE_TAG=v3.0.6` to the same `.env`:
+The backend entrypoint auto-generates a random `SECRET_KEY` on first start and applies the schema (`migrations/init.sql`) idempotently. Edit `backend.env` for persistent overrides (API keys, OAuth, broker credentials). Compose orchestration knobs go in a separate `.env` (optional) — e.g. pin a version:
 
 ```env
 IMAGE_TAG=v3.0.6

--- a/backend_api_python/Dockerfile
+++ b/backend_api_python/Dockerfile
@@ -3,24 +3,34 @@
 ARG BASE_IMAGE=python:3.12-slim-bookworm
 FROM ${BASE_IMAGE}
 
+# BUILD_REGION switches apt/PyPI sources:
+#   cn      -> Aliyun mirrors first, fall back to official on failure (default; zero-config for China)
+#   global  -> use Debian/PyPI official directly, skip Aliyun entirely (used by GitHub Actions runners)
+ARG BUILD_REGION=cn
+
 WORKDIR /app
 
-# Apt: try Aliyun Debian mirror first (typical win in mainland); on failure restore official.
-# No env vars — same Dockerfile works abroad (falls back) and in CN (usually hits mirror).
+# Apt: when BUILD_REGION=cn, try Aliyun Debian mirror first (typical win in mainland) and
+# restore official on failure. Otherwise go straight to official sources so overseas
+# builders (e.g. GitHub-hosted runners) don't waste time hitting cn mirrors.
 RUN set -eux; \
     APT_TIMEOUT='Acquire::http::Timeout=35'; \
-    if [ -f /etc/apt/sources.list.d/debian.sources ]; then \
-      cp /etc/apt/sources.list.d/debian.sources /tmp/debian.sources.bak; \
-      sed -i -E \
-        's|https?://deb.debian.org|https://mirrors.aliyun.com|g; s|https?://security.debian.org|https://mirrors.aliyun.com|g' \
-        /etc/apt/sources.list.d/debian.sources; \
-      if ! apt-get -o "$APT_TIMEOUT" -o Acquire::https::Timeout=35 update; then \
-        cp /tmp/debian.sources.bak /etc/apt/sources.list.d/debian.sources; \
+    if [ "$BUILD_REGION" = "cn" ]; then \
+      if [ -f /etc/apt/sources.list.d/debian.sources ]; then \
+        cp /etc/apt/sources.list.d/debian.sources /tmp/debian.sources.bak; \
+        sed -i -E \
+          's|https?://deb.debian.org|https://mirrors.aliyun.com|g; s|https?://security.debian.org|https://mirrors.aliyun.com|g' \
+          /etc/apt/sources.list.d/debian.sources; \
+        if ! apt-get -o "$APT_TIMEOUT" -o Acquire::https::Timeout=35 update; then \
+          cp /tmp/debian.sources.bak /etc/apt/sources.list.d/debian.sources; \
+          sed -i 's|http://deb.debian.org|https://deb.debian.org|g' /etc/apt/sources.list.d/*.sources 2>/dev/null || true; \
+          apt-get -o "$APT_TIMEOUT" update; \
+        fi; \
+      else \
         sed -i 's|http://deb.debian.org|https://deb.debian.org|g' /etc/apt/sources.list.d/*.sources 2>/dev/null || true; \
         apt-get -o "$APT_TIMEOUT" update; \
       fi; \
     else \
-      sed -i 's|http://deb.debian.org|https://deb.debian.org|g' /etc/apt/sources.list.d/*.sources 2>/dev/null || true; \
       apt-get -o "$APT_TIMEOUT" update; \
     fi; \
     apt-get install -y --no-install-recommends --fix-missing \
@@ -34,12 +44,17 @@ RUN set -eux; \
 
 COPY requirements.txt .
 
-# Pip: try Aliyun PyPI first; on any failure retry default index (PyPI.org).
+# Pip: when BUILD_REGION=cn, try Aliyun PyPI first; on any failure retry default index.
+# Otherwise install from PyPI official directly.
 RUN set -eux; \
-    pip install --no-cache-dir --prefer-binary --timeout 180 \
-        -i https://mirrors.aliyun.com/pypi/simple/ \
-        -r requirements.txt \
-      || pip install --no-cache-dir --prefer-binary --timeout 180 -r requirements.txt; \
+    if [ "$BUILD_REGION" = "cn" ]; then \
+      pip install --no-cache-dir --prefer-binary --timeout 180 \
+          -i https://mirrors.aliyun.com/pypi/simple/ \
+          -r requirements.txt \
+        || pip install --no-cache-dir --prefer-binary --timeout 180 -r requirements.txt; \
+    else \
+      pip install --no-cache-dir --prefer-binary --timeout 180 -r requirements.txt; \
+    fi; \
     apt-get purge -y --auto-remove build-essential python3-dev libffi-dev libssl-dev; \
     rm -rf /var/lib/apt/lists/*
 

--- a/backend_api_python/docker-entrypoint.sh
+++ b/backend_api_python/docker-entrypoint.sh
@@ -36,7 +36,15 @@ fi
 # Auto-generate SECRET_KEY if using default (zero-config experience)
 if [ "$CURRENT_SECRET" = "$DEFAULT_SECRET" ]; then
     NEW_SECRET=$(python3 -c "import secrets; print(secrets.token_hex(32))")
-    sed -i "s|SECRET_KEY=.*|SECRET_KEY=${NEW_SECRET}|" /app/.env
+    # Use a temp file + write-back instead of `sed -i`. When /app/.env is a
+    # Docker bind-mount from the host (zero-repo GHCR deploy), `sed -i` fails
+    # with "Device or resource busy" because it tries to rename(2) the inode
+    # over a mount target. Truncate+write through the mount works fine and
+    # propagates the new key back to the host file.
+    TMP=$(mktemp)
+    sed "s|SECRET_KEY=.*|SECRET_KEY=${NEW_SECRET}|" /app/.env > "$TMP"
+    cat "$TMP" > /app/.env
+    rm -f "$TMP"
     echo "[AUTO] Generated random SECRET_KEY (was default)."
     echo "[TIP]  For production, set a persistent SECRET_KEY in backend_api_python/.env"
 fi

--- a/docker-compose.ghcr.yml
+++ b/docker-compose.ghcr.yml
@@ -1,32 +1,27 @@
 # QuantDinger Docker Compose - GHCR prebuilt images (zero-repo deploy)
 #
 # Pulls both backend and frontend images from GitHub Container Registry. The
-# repository does NOT need to be cloned — only this file (and an optional
-# `.env` for runtime overrides) is required.
+# repository does NOT need to be cloned — only this file (plus a backend.env
+# for runtime config) is required.
 #
 # Minimal install (Linux / macOS):
 #
 #   curl -O https://raw.githubusercontent.com/brokermr810/QuantDinger/main/docker-compose.ghcr.yml
-#   # optional: download the env template and edit it for API keys / OAuth / brokers
-#   curl -o .env https://raw.githubusercontent.com/brokermr810/QuantDinger/main/backend_api_python/env.example
+#   curl -o backend.env https://raw.githubusercontent.com/brokermr810/QuantDinger/main/backend_api_python/env.example
 #   docker compose -f docker-compose.ghcr.yml up -d
 #   # open http://localhost:8888  (login: quantdinger / 123456)
 #
-# Without a `.env` the backend entrypoint will materialize a fresh config inside
-# the container and auto-generate SECRET_KEY on first start, so nothing is
-# required for a smoke test. Provide your own `.env` once you need persistent
-# overrides (API keys, ADMIN_USER, broker creds, etc.).
-#
-# A single root `.env` serves both purposes here:
-#   - docker compose reads it for ${VAR} substitution (IMAGE_TAG, ports, ...)
-#   - the backend container bind-mounts it as /app/.env (SECRET_KEY, API keys, ...)
-# Unreferenced backend vars are simply ignored by compose.
+# Two-file separation of concerns:
+#   - backend.env   — backend runtime config (SECRET_KEY, API keys, broker creds, ...);
+#                     bind-mounted into the backend container as /app/.env
+#   - .env (optional) — docker compose orchestration knobs (IMAGE_TAG, ports, mirrors);
+#                       read by `docker compose` itself for ${VAR} substitution
 #
 # Database schema is bootstrapped automatically: the backend re-applies
 # `migrations/init.sql` idempotently on every start, so no host-side SQL
 # mount is needed (unlike docker-compose.yml).
 #
-# Override knobs (write into the same root `.env`):
+# Orchestration override knobs (project-root .env, all optional):
 #   IMAGE_TAG       - backend & frontend tag (default: latest)
 #   BACKEND_IMAGE   - backend image path  (default: ghcr.io/brokermr810/quantdinger-backend)
 #   FRONTEND_IMAGE  - frontend image path (default: ghcr.io/brokermr810/quantdinger-frontend)
@@ -89,12 +84,12 @@ services:
     volumes:
       - backend_logs:/app/logs
       - backend_data:/app/data
-      # Runtime config. The project-root .env (also used by compose itself for
-      # ${VAR} substitution) is bind-mounted as /app/.env. If the host file is
-      # missing, docker creates a directory at the mount target instead of a
-      # file and shadows /app/.env — comment this line out for true config-less
-      # smoke tests, or just `touch .env` before `up -d`.
-      - ./.env:/app/.env
+      # Backend runtime config. Must exist as a *file* on the host — if missing,
+      # docker silently creates a directory at the mount target and shadows
+      # /app/.env. The entrypoint will auto-generate SECRET_KEY on first start
+      # and write it back through the bind mount, so the host file gets the
+      # generated key persistently.
+      - ./backend.env:/app/.env
     environment:
       - PYTHON_API_HOST=0.0.0.0
       - PYTHON_API_PORT=5000

--- a/docker-compose.ghcr.yml
+++ b/docker-compose.ghcr.yml
@@ -1,31 +1,38 @@
-# QuantDinger Docker Compose - One-Click Deployment
-# Usage:
-#   1. Copy env.example to .env and edit your settings
-#      cp backend_api_python/env.example backend_api_python/.env
-#   2. IMPORTANT: Generate and set a secure SECRET_KEY in backend_api_python/.env
-#      SECRET_KEY=$(python3 -c "import secrets; print(secrets.token_hex(32))")
-#      Or edit backend_api_python/.env and replace SECRET_KEY value
-#   3. docker-compose up -d --build
-#   4. Open http://localhost:8888
+# QuantDinger Docker Compose - GHCR prebuilt images (zero-repo deploy)
 #
-# Frontend image: nginx serving prebuilt files from `frontend/dist` only.
-# Vue source is maintained separately; build there and sync dist into this repo.
+# Pulls both backend and frontend images from GitHub Container Registry. The
+# repository does NOT need to be cloned — only this file (and an optional
+# `.env` for runtime overrides) is required.
 #
-# Note: The container will NOT start if SECRET_KEY is using the default value.
-#       This is a security measure to prevent insecure deployments.
+# Minimal install (Linux / macOS):
 #
-# Docker image sources:
-#   Default uses official Docker Hub images.
-#   To switch source globally, set a single `IMAGE_PREFIX` in project-root `.env`.
-#   Examples: empty (official), `docker.m.daocloud.io/library/`,
-#   `docker.xuanyuan.me/library/`.
-# Backend Dockerfile tries Aliyun apt/PyPI first and falls back to official (no extra env).
-# For slow pulls of base images, optionally set IMAGE_PREFIX or Docker Engine registry-mirrors.
+#   curl -O https://raw.githubusercontent.com/brokermr810/QuantDinger/main/docker-compose.ghcr.yml
+#   # optional: download the env template and edit it for API keys / OAuth / brokers
+#   curl -o .env https://raw.githubusercontent.com/brokermr810/QuantDinger/main/backend_api_python/env.example
+#   docker compose -f docker-compose.ghcr.yml up -d
+#   # open http://localhost:8888  (login: quantdinger / 123456)
+#
+# Without a `.env` the backend entrypoint will materialize a fresh config inside
+# the container and auto-generate SECRET_KEY on first start, so nothing is
+# required for a smoke test. Provide your own `.env` once you need persistent
+# overrides (API keys, ADMIN_USER, broker creds, etc.).
+#
+# A single root `.env` serves both purposes here:
+#   - docker compose reads it for ${VAR} substitution (IMAGE_TAG, ports, ...)
+#   - the backend container bind-mounts it as /app/.env (SECRET_KEY, API keys, ...)
+# Unreferenced backend vars are simply ignored by compose.
+#
+# Database schema is bootstrapped automatically: the backend re-applies
+# `migrations/init.sql` idempotently on every start, so no host-side SQL
+# mount is needed (unlike docker-compose.yml).
+#
+# Override knobs (write into the same root `.env`):
+#   IMAGE_TAG       - backend & frontend tag (default: latest)
+#   BACKEND_IMAGE   - backend image path  (default: ghcr.io/brokermr810/quantdinger-backend)
+#   FRONTEND_IMAGE  - frontend image path (default: ghcr.io/brokermr810/quantdinger-frontend)
+#   IMAGE_PREFIX    - postgres/redis registry prefix (e.g. docker.m.daocloud.io/library/)
 
 services:
-  # ========================
-  # PostgreSQL Database
-  # ========================
   postgres:
     image: ${IMAGE_PREFIX:-}postgres:16-alpine
     container_name: quantdinger-db
@@ -35,9 +42,6 @@ services:
       POSTGRES_USER: ${POSTGRES_USER:-quantdinger}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-quantdinger123}
       TZ: ${TZ:-Asia/Shanghai}
-    # Raise PostgreSQL's max_connections so the backend pool (default
-    # DB_POOL_MAX=50) plus psql/admin connections never exceed PG's own
-    # limit.  PG default is 100; 150 gives headroom for future scaling.
     command:
       - "postgres"
       - "-c"
@@ -46,7 +50,6 @@ services:
       - "shared_buffers=${PG_SHARED_BUFFERS:-256MB}"
     volumes:
       - postgres_data:/var/lib/postgresql/data
-      - ./backend_api_python/migrations/init.sql:/docker-entrypoint-initdb.d/01-init.sql
     ports:
       - "${DB_PORT:-127.0.0.1:5432}:5432"
     networks:
@@ -57,9 +60,6 @@ services:
       timeout: 5s
       retries: 5
 
-  # ========================
-  # Redis (optional cache layer)
-  # ========================
   redis:
     image: ${IMAGE_PREFIX:-}redis:7-alpine
     container_name: quantdinger-redis
@@ -75,18 +75,8 @@ services:
       timeout: 5s
       retries: 5
 
-  # ========================
-  # Backend API (Python/Flask)
-  # ========================
   backend:
-    build:
-      context: ./backend_api_python
-      dockerfile: Dockerfile
-      args:
-        BASE_IMAGE: ${IMAGE_PREFIX:-}python:3.12-slim-bookworm
-        # cn (default): use Aliyun apt/PyPI mirrors with fallback to official.
-        # global: use official sources directly (recommended for overseas builds).
-        BUILD_REGION: ${BUILD_REGION:-cn}
+    image: ${BACKEND_IMAGE:-ghcr.io/brokermr810/quantdinger-backend}:${IMAGE_TAG:-latest}
     container_name: quantdinger-backend
     restart: unless-stopped
     depends_on:
@@ -99,8 +89,12 @@ services:
     volumes:
       - backend_logs:/app/logs
       - backend_data:/app/data
-      # Mount .env for runtime config and admin-panel updates
-      - ./backend_api_python/.env:/app/.env
+      # Runtime config. The project-root .env (also used by compose itself for
+      # ${VAR} substitution) is bind-mounted as /app/.env. If the host file is
+      # missing, docker creates a directory at the mount target instead of a
+      # file and shadows /app/.env — comment this line out for true config-less
+      # smoke tests, or just `touch .env` before `up -d`.
+      - ./.env:/app/.env
     environment:
       - PYTHON_API_HOST=0.0.0.0
       - PYTHON_API_PORT=5000
@@ -110,20 +104,14 @@ services:
       - REDIS_HOST=redis
       - REDIS_PORT=6379
       - CACHE_ENABLED=true
-      # Database connection pool tuning (see app/utils/db_postgres.py).
-      # Defaults are safe for ~50 concurrent DB users; raise if you run many
-      # bots or see `connection pool exhausted` errors.
       - DB_POOL_MIN=${DB_POOL_MIN:-5}
       - DB_POOL_MAX=${DB_POOL_MAX:-50}
       - DB_POOL_ACQUIRE_TIMEOUT=${DB_POOL_ACQUIRE_TIMEOUT:-10}
       - DB_POOL_HEALTH_CHECK=${DB_POOL_HEALTH_CHECK:-true}
-      # Route-level executor tuning (each worker may use one DB connection).
       - MARKET_EXECUTOR_WORKERS=${MARKET_EXECUTOR_WORKERS:-6}
       - PORTFOLIO_EXECUTOR_WORKERS=${PORTFOLIO_EXECUTOR_WORKERS:-3}
-      # Gunicorn concurrency (threads within the single worker process).
       - GUNICORN_WORKERS=${GUNICORN_WORKERS:-1}
       - GUNICORN_THREADS=${GUNICORN_THREADS:-8}
-      # IBKR/MT5 need local TWS or MT5 terminal; set false on SaaS cloud (see env.example).
       - ALLOW_LOCAL_DESKTOP_BROKERS=${ALLOW_LOCAL_DESKTOP_BROKERS:-true}
     networks:
       - quantdinger-network
@@ -133,23 +121,13 @@ services:
       timeout: 10s
       retries: 3
 
-  # ========================
-  # Frontend (Nginx serving prebuilt dist)
-  # ========================
   frontend:
-    build:
-      context: ./frontend
-      dockerfile: Dockerfile
-      args:
-        RUNTIME_IMAGE: ${IMAGE_PREFIX:-}nginx:1.25-alpine
+    image: ${FRONTEND_IMAGE:-ghcr.io/brokermr810/quantdinger-frontend}:${IMAGE_TAG:-latest}
     container_name: quantdinger-frontend
     restart: unless-stopped
     ports:
       - "${FRONTEND_PORT:-8888}:80"
     environment:
-      # nginx envsubst will inject this into the proxy_pass directive at start.
-      # Override with the backend's reachable URL when deploying outside compose
-      # (e.g. Railway: http://${{Backend.RAILWAY_PRIVATE_DOMAIN}}:5000).
       - BACKEND_URL=${BACKEND_URL:-http://backend:5000}
     depends_on:
       - backend

--- a/docs/README_AR.md
+++ b/docs/README_AR.md
@@ -225,7 +225,7 @@ flowchart LR
    - **بديل (بدون استنساخ المستودع)**: اسحب صور backend + frontend الجاهزة المتعددة المعماريات (amd64/arm64) من GHCR مباشرة:
      ```bash
      curl -O https://raw.githubusercontent.com/brokermr810/QuantDinger/main/docker-compose.ghcr.yml
-     curl -o .env https://raw.githubusercontent.com/brokermr810/QuantDinger/main/backend_api_python/env.example
+     curl -o backend.env https://raw.githubusercontent.com/brokermr810/QuantDinger/main/backend_api_python/env.example
      docker compose -f docker-compose.ghcr.yml up -d
      ```
      الصور الافتراضية: `ghcr.io/brokermr810/quantdinger-{backend,frontend}:latest`. لتثبيت إصدار محدد اضبط `IMAGE_TAG=v3.0.6` في ملف `.env` محلي.

--- a/docs/README_AR.md
+++ b/docs/README_AR.md
@@ -222,6 +222,13 @@ flowchart LR
 1. استنسخ المستودع ثم `cp backend_api_python/env.example backend_api_python/.env`
 2. **يجب تعيين `SECRET_KEY`** (القيمة الافتراضية تمنع تشغيل الخلفية). Linux/macOS: `./scripts/generate-secret-key.sh`
 3. `docker-compose up -d --build`
+   - **بديل (بدون استنساخ المستودع)**: اسحب صور backend + frontend الجاهزة المتعددة المعماريات (amd64/arm64) من GHCR مباشرة:
+     ```bash
+     curl -O https://raw.githubusercontent.com/brokermr810/QuantDinger/main/docker-compose.ghcr.yml
+     curl -o .env https://raw.githubusercontent.com/brokermr810/QuantDinger/main/backend_api_python/env.example
+     docker compose -f docker-compose.ghcr.yml up -d
+     ```
+     الصور الافتراضية: `ghcr.io/brokermr810/quantdinger-{backend,frontend}:latest`. لتثبيت إصدار محدد اضبط `IMAGE_TAG=v3.0.6` في ملف `.env` محلي.
 4. **الويب:** `http://localhost:8888` · **صحة API:** `http://localhost:5000/api/health`
 5. غيّر كلمة مرور المسؤول الافتراضية قبل الإنتاج. اضبط **`FRONTEND_URL`** في `backend_api_python/.env` على عنوانك الفعلي.
 

--- a/docs/README_CN.md
+++ b/docs/README_CN.md
@@ -383,6 +383,26 @@ docker-compose up -d --build
 
 默认服务：**`postgres`**、**`redis`**、**`backend`**、**`frontend`**（详见仓库根目录 `docker-compose.yml` 与健康检查）。
 
+#### 备选方案：零仓库安装（GHCR 预构建镜像）
+
+如果不想 clone 整个仓库，可使用 GHCR 变体——后端和前端都是预构建的多架构（amd64/arm64）镜像：
+
+```bash
+curl -O https://raw.githubusercontent.com/brokermr810/QuantDinger/main/docker-compose.ghcr.yml
+curl -o .env https://raw.githubusercontent.com/brokermr810/QuantDinger/main/backend_api_python/env.example
+docker compose -f docker-compose.ghcr.yml up -d
+```
+
+后端 entrypoint 会在首次启动时自动生成随机 `SECRET_KEY` 并幂等地应用 `migrations/init.sql`。编辑 `.env` 用于持久化覆盖（API 密钥、OAuth、券商凭据等）。生产环境建议在同一份 `.env` 末尾追加 pin 版本：
+
+```env
+IMAGE_TAG=v3.0.6
+# BACKEND_IMAGE=ghcr.io/<你的fork>/quantdinger-backend     # 可选，用于 fork
+# FRONTEND_IMAGE=ghcr.io/<你的fork>/quantdinger-frontend
+```
+
+默认镜像：`ghcr.io/brokermr810/quantdinger-backend:latest` + `ghcr.io/brokermr810/quantdinger-frontend:latest`。
+
 ### 5）验证与登录
 
 | 检查项 | 地址 / 命令 |

--- a/docs/README_CN.md
+++ b/docs/README_CN.md
@@ -389,11 +389,11 @@ docker-compose up -d --build
 
 ```bash
 curl -O https://raw.githubusercontent.com/brokermr810/QuantDinger/main/docker-compose.ghcr.yml
-curl -o .env https://raw.githubusercontent.com/brokermr810/QuantDinger/main/backend_api_python/env.example
+curl -o backend.env https://raw.githubusercontent.com/brokermr810/QuantDinger/main/backend_api_python/env.example
 docker compose -f docker-compose.ghcr.yml up -d
 ```
 
-后端 entrypoint 会在首次启动时自动生成随机 `SECRET_KEY` 并幂等地应用 `migrations/init.sql`。编辑 `.env` 用于持久化覆盖（API 密钥、OAuth、券商凭据等）。生产环境建议在同一份 `.env` 末尾追加 pin 版本：
+后端 entrypoint 会在首次启动时自动生成随机 `SECRET_KEY` 并幂等地应用 `migrations/init.sql`。编辑 `backend.env` 用于持久化覆盖（API 密钥、OAuth、券商凭据等）。编排参数（pin 版本、换镜像源等）放在独立的 `.env`（可选）：
 
 ```env
 IMAGE_TAG=v3.0.6

--- a/docs/README_JA.md
+++ b/docs/README_JA.md
@@ -203,7 +203,7 @@ flowchart LR
    - **代替（リポジトリ不要）**：プリビルド多架構（amd64/arm64）の backend + frontend を GHCR から直接プルする場合：
      ```bash
      curl -O https://raw.githubusercontent.com/brokermr810/QuantDinger/main/docker-compose.ghcr.yml
-     curl -o .env https://raw.githubusercontent.com/brokermr810/QuantDinger/main/backend_api_python/env.example
+     curl -o backend.env https://raw.githubusercontent.com/brokermr810/QuantDinger/main/backend_api_python/env.example
      docker compose -f docker-compose.ghcr.yml up -d
      ```
      デフォルトイメージは `ghcr.io/brokermr810/quantdinger-{backend,frontend}:latest`。バージョン固定はローカル `.env` で `IMAGE_TAG=v3.0.6`。

--- a/docs/README_JA.md
+++ b/docs/README_JA.md
@@ -200,6 +200,13 @@ flowchart LR
 1. リポジトリをクローンし、`cp backend_api_python/env.example backend_api_python/.env`
 2. **`SECRET_KEY` を必ず設定**（プレースホルダのままではバックエンドが起動しません）。Linux/macOS: `./scripts/generate-secret-key.sh`
 3. `docker-compose up -d --build`
+   - **代替（リポジトリ不要）**：プリビルド多架構（amd64/arm64）の backend + frontend を GHCR から直接プルする場合：
+     ```bash
+     curl -O https://raw.githubusercontent.com/brokermr810/QuantDinger/main/docker-compose.ghcr.yml
+     curl -o .env https://raw.githubusercontent.com/brokermr810/QuantDinger/main/backend_api_python/env.example
+     docker compose -f docker-compose.ghcr.yml up -d
+     ```
+     デフォルトイメージは `ghcr.io/brokermr810/quantdinger-{backend,frontend}:latest`。バージョン固定はローカル `.env` で `IMAGE_TAG=v3.0.6`。
 4. **Web:** `http://localhost:8888` · **API ヘルス:** `http://localhost:5000/api/health`
 5. 本番前にデフォルト管理者パスワードを変更。`backend_api_python/.env` の **`FRONTEND_URL`** を実際の URL に合わせる。
 

--- a/docs/README_KO.md
+++ b/docs/README_KO.md
@@ -200,6 +200,13 @@ flowchart LR
 1. 클론 후 `cp backend_api_python/env.example backend_api_python/.env`
 2. **`SECRET_KEY` 필수 설정**(플레이스홀더면 백엔드가 시작되지 않음). Linux/macOS: `./scripts/generate-secret-key.sh`
 3. `docker-compose up -d --build`
+   - **대안 (저장소 불필요)**: backend + frontend 모두 GHCR의 프리빌드 멀티 아키텍처(amd64/arm64) 이미지를 직접 풀:
+     ```bash
+     curl -O https://raw.githubusercontent.com/brokermr810/QuantDinger/main/docker-compose.ghcr.yml
+     curl -o .env https://raw.githubusercontent.com/brokermr810/QuantDinger/main/backend_api_python/env.example
+     docker compose -f docker-compose.ghcr.yml up -d
+     ```
+     기본 이미지: `ghcr.io/brokermr810/quantdinger-{backend,frontend}:latest`. 버전 고정은 로컬 `.env`에 `IMAGE_TAG=v3.0.6`.
 4. **Web:** `http://localhost:8888` · **API 헬스:** `http://localhost:5000/api/health`
 5. 프로덕션 전 기본 관리자 비밀번호 변경. `backend_api_python/.env`의 **`FRONTEND_URL`**을 실제 URL에 맞추세요.
 

--- a/docs/README_KO.md
+++ b/docs/README_KO.md
@@ -203,7 +203,7 @@ flowchart LR
    - **대안 (저장소 불필요)**: backend + frontend 모두 GHCR의 프리빌드 멀티 아키텍처(amd64/arm64) 이미지를 직접 풀:
      ```bash
      curl -O https://raw.githubusercontent.com/brokermr810/QuantDinger/main/docker-compose.ghcr.yml
-     curl -o .env https://raw.githubusercontent.com/brokermr810/QuantDinger/main/backend_api_python/env.example
+     curl -o backend.env https://raw.githubusercontent.com/brokermr810/QuantDinger/main/backend_api_python/env.example
      docker compose -f docker-compose.ghcr.yml up -d
      ```
      기본 이미지: `ghcr.io/brokermr810/quantdinger-{backend,frontend}:latest`. 버전 고정은 로컬 `.env`에 `IMAGE_TAG=v3.0.6`.

--- a/docs/README_TH.md
+++ b/docs/README_TH.md
@@ -203,7 +203,7 @@ flowchart LR
    - **ทางเลือก (ไม่ต้อง clone repo)**: ดึงอิมเมจ backend + frontend สำเร็จรูปแบบหลายสถาปัตยกรรม (amd64/arm64) จาก GHCR โดยตรง:
      ```bash
      curl -O https://raw.githubusercontent.com/brokermr810/QuantDinger/main/docker-compose.ghcr.yml
-     curl -o .env https://raw.githubusercontent.com/brokermr810/QuantDinger/main/backend_api_python/env.example
+     curl -o backend.env https://raw.githubusercontent.com/brokermr810/QuantDinger/main/backend_api_python/env.example
      docker compose -f docker-compose.ghcr.yml up -d
      ```
      อิมเมจเริ่มต้น: `ghcr.io/brokermr810/quantdinger-{backend,frontend}:latest` ตรึงเวอร์ชันด้วย `IMAGE_TAG=v3.0.6` ใน `.env` ที่อยู่ในเครื่อง

--- a/docs/README_TH.md
+++ b/docs/README_TH.md
@@ -200,6 +200,13 @@ flowchart LR
 1. โคลนแล้ว `cp backend_api_python/env.example backend_api_python/.env`
 2. **ต้องตั้ง `SECRET_KEY`** (ถ้าเป็นค่า placeholder แบ็กเอนด์จะไม่เริ่ม) Linux/macOS: `./scripts/generate-secret-key.sh`
 3. `docker-compose up -d --build`
+   - **ทางเลือก (ไม่ต้อง clone repo)**: ดึงอิมเมจ backend + frontend สำเร็จรูปแบบหลายสถาปัตยกรรม (amd64/arm64) จาก GHCR โดยตรง:
+     ```bash
+     curl -O https://raw.githubusercontent.com/brokermr810/QuantDinger/main/docker-compose.ghcr.yml
+     curl -o .env https://raw.githubusercontent.com/brokermr810/QuantDinger/main/backend_api_python/env.example
+     docker compose -f docker-compose.ghcr.yml up -d
+     ```
+     อิมเมจเริ่มต้น: `ghcr.io/brokermr810/quantdinger-{backend,frontend}:latest` ตรึงเวอร์ชันด้วย `IMAGE_TAG=v3.0.6` ใน `.env` ที่อยู่ในเครื่อง
 4. **เว็บ:** `http://localhost:8888` · **สุขภาพ API:** `http://localhost:5000/api/health`
 5. เปลี่ยนรหัสผู้ดูแลเริ่มต้นก่อนโปรดักชัน ตั้ง **`FRONTEND_URL`** ใน `backend_api_python/.env` ให้ตรง URL จริง
 

--- a/docs/README_VI.md
+++ b/docs/README_VI.md
@@ -203,7 +203,7 @@ flowchart LR
    - **Tùy chọn (không cần clone repo)**: kéo image backend + frontend đa kiến trúc (amd64/arm64) sẵn từ GHCR:
      ```bash
      curl -O https://raw.githubusercontent.com/brokermr810/QuantDinger/main/docker-compose.ghcr.yml
-     curl -o .env https://raw.githubusercontent.com/brokermr810/QuantDinger/main/backend_api_python/env.example
+     curl -o backend.env https://raw.githubusercontent.com/brokermr810/QuantDinger/main/backend_api_python/env.example
      docker compose -f docker-compose.ghcr.yml up -d
      ```
      Image mặc định: `ghcr.io/brokermr810/quantdinger-{backend,frontend}:latest`. Ghim phiên bản bằng `IMAGE_TAG=v3.0.6` trong `.env` cục bộ.

--- a/docs/README_VI.md
+++ b/docs/README_VI.md
@@ -200,6 +200,13 @@ flowchart LR
 1. Clone rồi `cp backend_api_python/env.example backend_api_python/.env`
 2. **Phải đặt `SECRET_KEY`** (giữ placeholder thì backend không khởi động). Linux/macOS: `./scripts/generate-secret-key.sh`
 3. `docker-compose up -d --build`
+   - **Tùy chọn (không cần clone repo)**: kéo image backend + frontend đa kiến trúc (amd64/arm64) sẵn từ GHCR:
+     ```bash
+     curl -O https://raw.githubusercontent.com/brokermr810/QuantDinger/main/docker-compose.ghcr.yml
+     curl -o .env https://raw.githubusercontent.com/brokermr810/QuantDinger/main/backend_api_python/env.example
+     docker compose -f docker-compose.ghcr.yml up -d
+     ```
+     Image mặc định: `ghcr.io/brokermr810/quantdinger-{backend,frontend}:latest`. Ghim phiên bản bằng `IMAGE_TAG=v3.0.6` trong `.env` cục bộ.
 4. **Web:** `http://localhost:8888` · **Sức khỏe API:** `http://localhost:5000/api/health`
 5. Đổi mật khẩu quản trị mặc định trước production. Đặt **`FRONTEND_URL`** trong `backend_api_python/.env` đúng URL thực tế.
 


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow that builds multi-arch (amd64/arm64) backend + frontend images on `v*` tag push and publishes to GHCR.
- Add `docker-compose.ghcr.yml` so users can deploy without cloning the repo — pulls prebuilt images, backend self-applies `init.sql`.
- Split orchestration `.env` (compose `${VAR}` substitution, ~5 keys) from backend runtime `backend.env` (200+ keys) to keep concerns separate.
- Backend Dockerfile: new `BUILD_REGION` arg (`cn` uses Aliyun mirrors + fallback, `global` official only); CN remains the zero-config default, CI builds with `global`.
- Fix `SECRET_KEY` auto-gen to work with bind-mounted single-file `.env` (switch from `sed -i` rename to `mktemp` + write-back).
- READMEs (EN/CN/JA/KO/TH/VI/AR) + `.env.example` updated with the zero-repo install snippet and new knobs (`BUILD_REGION`, `IMAGE_TAG`, `BACKEND_IMAGE`, `FRONTEND_IMAGE`).
- `basic-ci.yml`: add `compose-check` job validating both compose files.

## Test plan
- [x] Tag push triggers `docker-publish.yml`, both images appear on GHCR with `amd64`+`arm64`.
- [x] `docker compose -f docker-compose.ghcr.yml up -d` on a clean host (no repo clone) boots backend + frontend; `SECRET_KEY` is generated and persisted to host `backend.env`.
- [x] `docker compose up -d` (build mode) still works against existing `backend_api_python/.env`.
- [x] `compose-check` CI job passes on both files.