### PR TITLE
输出用户自定义日志，方便策略跟踪

### DIFF
--- a/backend_api_python/app/services/strategy_script_runtime.py
+++ b/backend_api_python/app/services/strategy_script_runtime.py
@@ -146,6 +146,11 @@ class StrategyScriptContext:
     def log(self, message: Any):
         self._logs.append(str(message))
 
+    def flush_logs(self) -> List[str]:
+        logs = self._logs.copy()
+        self._logs = []
+        return logs
+
     def buy(self, price: Any = None, amount: Any = None):
         self._orders.append({'action': 'buy', 'price': price, 'amount': amount})
 

--- a/backend_api_python/app/services/trading_executor.py
+++ b/backend_api_python/app/services/trading_executor.py
@@ -923,6 +923,12 @@ class TradingExecutor:
         logger.info(f"Strategy {strategy_id} script closed bar {closed_ts} -> {len(pending)} signal(s)")
         return pending, closed_ts
 
+    def _flush_ctx_logs(self,strategy_id,ctx):
+        """Flush ctx user defined logs to strategy log table."""
+        logs = ctx.flush_logs()
+        for log in logs:
+            append_strategy_log(strategy_id, "info", log)
+
     def _script_evaluate_in_progress_bar(
         self,
         df: pd.DataFrame,
@@ -971,6 +977,7 @@ class TradingExecutor:
         )
         try:
             on_bar(ctx, bar)
+            self._flush_ctx_logs(strategy_id, ctx)
         except Exception as e:
             logger.error(f"Strategy {strategy_id} script in-progress on_bar error: {e}")
             logger.error(traceback.format_exc())


### PR DESCRIPTION
## Summary

将script策略中用户自定义的日志输出到策略中，方便用户跟踪策略运行

## Changes

- 

## Test plan

- [ ] Tested locally with `docker compose up -d --build`
- [ ] Backend logs show no errors
- [ ] Relevant pytest tests pass

## Screenshots (if UI change)

<!-- Paste before/after screenshots -->
