### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/backend_api_python/app/routes/market.py
+++ b/backend_api_python/app/routes/market.py
@@ -180,7 +180,7 @@ def get_public_config():
                 'openai/gpt-5-mini': 'OpenAI: GPT-5 Mini',
                 'openai/gpt-4.1-mini': 'OpenAI: GPT-4.1 Mini',
                 'deepseek/deepseek-v3.2': 'DeepSeek: DeepSeek V3.2',
-                'minimax/minimax-m2': 'MiniMax: MiniMax M2',
+                'minimax/minimax-m3': 'MiniMax: MiniMax M3',
                 'anthropic/claude-sonnet-4': 'Anthropic: Claude Sonnet 4',
                 'anthropic/claude-sonnet-4.5': 'Anthropic: Claude Sonnet 4.5',
                 'anthropic/claude-opus-4.5': 'Anthropic: Claude Opus 4.5',

--- a/backend_api_python/app/routes/settings.py
+++ b/backend_api_python/app/routes/settings.py
@@ -537,8 +537,8 @@ CONFIG_SCHEMA = {
                 'key': 'MINIMAX_MODEL',
                 'label': 'MiniMax Model',
                 'type': 'text',
-                'default': 'MiniMax-M2.7',
-                'description': 'Model: MiniMax-M2.7, MiniMax-M2.7-highspeed',
+                'default': 'MiniMax-M3',
+                'description': 'Model: MiniMax-M3, MiniMax-M2.7, MiniMax-M2.7-highspeed',
                 'group': 'minimax'
             },
             {

--- a/backend_api_python/app/services/llm.py
+++ b/backend_api_python/app/services/llm.py
@@ -61,8 +61,8 @@ PROVIDER_CONFIGS = {
     },
     LLMProvider.MINIMAX: {
         "base_url": "https://api.minimax.io/v1",
-        "default_model": "MiniMax-M2.7",
-        "fallback_model": "MiniMax-M2.7-highspeed",
+        "default_model": "MiniMax-M3",
+        "fallback_model": "MiniMax-M2.7",
     },
 }
 

--- a/backend_api_python/env.example
+++ b/backend_api_python/env.example
@@ -158,7 +158,7 @@ CUSTOM_MODEL=
 
 # MiniMax (set LLM_PROVIDER=minimax)
 MINIMAX_API_KEY=
-MINIMAX_MODEL=MiniMax-M2.7
+MINIMAX_MODEL=MiniMax-M3
 MINIMAX_BASE_URL=https://api.minimax.io/v1
 
 # =========================


### PR DESCRIPTION
## Summary
Upgrade the MiniMax LLM provider configuration to use the latest **MiniMax-M3** as the default model, while keeping M2.7 and M2.7-highspeed as available options.

## Changes
- `backend_api_python/app/services/llm.py` - Set `default_model` to `MiniMax-M3`; keep `MiniMax-M2.7` as fallback.
- `backend_api_python/app/routes/settings.py` - Update `MINIMAX_MODEL` default to `MiniMax-M3`; description now lists M3, M2.7 and M2.7-highspeed.
- `backend_api_python/app/routes/market.py` - Replace `minimax/minimax-m2` entry in the public model list with `minimax/minimax-m3` / `MiniMax: MiniMax M3`.
- `backend_api_python/env.example` - Bump `MINIMAX_MODEL` example to `MiniMax-M3`.

## Why
MiniMax-M3 is the new flagship model with a 512K context window, 128K max output, and image input support across both OpenAI-compatible and Anthropic-compatible interfaces. M2.7 and the low-latency M2.7-highspeed variant remain available for users who prefer the previous generation.

## How to test
- Set `LLM_PROVIDER=minimax` and `MINIMAX_API_KEY=...` in `.env` (no `MINIMAX_MODEL` override).
- Start the backend (`python run.py`) and trigger any AI analysis path; verify the request hits `https://api.minimax.io/v1` with `MiniMax-M3`.
- Optionally set `MINIMAX_MODEL=MiniMax-M2.7` (or `MiniMax-M2.7-highspeed`) and confirm the prior generation still works.

## Backward compatibility
Existing users with an explicit `MINIMAX_MODEL` override (e.g. `MiniMax-M2.7` or `MiniMax-M2.7-highspeed`) are unaffected. Only the default for users who never set `MINIMAX_MODEL` changes from M2.7 to M3.