### PR TITLE
feat: add LiteLLM as unified LLM provider

### DIFF
--- a/backend_api_python/app/config/api_keys.py
+++ b/backend_api_python/app/config/api_keys.py
@@ -139,6 +139,16 @@ class MetaAPIKeys(type):
         from app.utils.config_loader import load_addon_config
         val = load_addon_config().get('minimax', {}).get('api_key')
         return val if val else ''
+
+    @property
+    def LITELLM_API_KEY(cls):
+        """LiteLLM API key (optional, litellm reads provider env vars automatically)"""
+        env_val = os.getenv('LITELLM_API_KEY', '').strip()
+        if env_val:
+            return env_val
+        from app.utils.config_loader import load_addon_config
+        val = load_addon_config().get('litellm', {}).get('api_key')
+        return val if val else ''
     
     @property
     def TAVILY_API_KEYS(cls):

--- a/backend_api_python/app/routes/settings.py
+++ b/backend_api_python/app/routes/settings.py
@@ -365,6 +365,7 @@ CONFIG_SCHEMA = {
                     {'value': 'grok', 'label': 'xAI Grok'},
                     {'value': 'custom', 'label': 'Custom API (OpenAI-compatible)'},
                     {'value': 'minimax', 'label': 'MiniMax'},
+                    {'value': 'litellm', 'label': 'LiteLLM (100+ providers)'},
                 ],
                 'description': 'Select your preferred LLM provider'
             },
@@ -548,6 +549,33 @@ CONFIG_SCHEMA = {
                 'default': 'https://api.minimax.io/v1',
                 'description': 'MiniMax API endpoint',
                 'group': 'minimax'
+            },
+            # LiteLLM
+            {
+                'key': 'LITELLM_API_KEY',
+                'label': 'LiteLLM API Key',
+                'type': 'password',
+                'required': False,
+                'link': 'https://docs.litellm.ai/docs/providers',
+                'link_text': 'settings.link.viewProviders',
+                'description': 'Optional. LiteLLM reads provider-specific env vars (OPENAI_API_KEY, ANTHROPIC_API_KEY, etc.) automatically',
+                'group': 'litellm'
+            },
+            {
+                'key': 'LITELLM_MODEL',
+                'label': 'LiteLLM Model',
+                'type': 'text',
+                'default': 'gpt-4o-mini',
+                'description': 'Model ID in provider/model format, e.g. anthropic/claude-sonnet-4-20250514, gemini/gemini-2.5-flash, azure/gpt-4o',
+                'group': 'litellm'
+            },
+            {
+                'key': 'LITELLM_BASE_URL',
+                'label': 'LiteLLM Base URL',
+                'type': 'text',
+                'default': '',
+                'description': 'Optional. Override provider base URL (e.g. Azure endpoint)',
+                'group': 'litellm'
             },
             # Common settings
             {

--- a/backend_api_python/app/services/llm.py
+++ b/backend_api_python/app/services/llm.py
@@ -25,6 +25,7 @@ class LLMProvider(Enum):
     GROK = "grok"
     CUSTOM = "custom"
     MINIMAX = "minimax"
+    LITELLM = "litellm"
 
 
 # Provider configurations
@@ -63,6 +64,11 @@ PROVIDER_CONFIGS = {
         "base_url": "https://api.minimax.io/v1",
         "default_model": "MiniMax-M2.7",
         "fallback_model": "MiniMax-M2.7-highspeed",
+    },
+    LLMProvider.LITELLM: {
+        "base_url": "",  # LiteLLM SDK handles routing
+        "default_model": "gpt-4o-mini",
+        "fallback_model": "gpt-4o-mini",
     },
 }
 
@@ -103,6 +109,7 @@ class LLMService:
         
         # Auto-detect: find any provider with a configured API key
         # Priority: DeepSeek > Grok > MiniMax > OpenAI > Google > OpenRouter
+        # (LiteLLM excluded from auto-detect; must be set explicitly via LLM_PROVIDER=litellm)
         priority_order = [
             LLMProvider.DEEPSEEK,
             LLMProvider.GROK,
@@ -132,6 +139,7 @@ class LLMService:
             LLMProvider.GROK: APIKeys.GROK_API_KEY,
             LLMProvider.CUSTOM: APIKeys.CUSTOM_API_KEY,
             LLMProvider.MINIMAX: APIKeys.MINIMAX_API_KEY,
+            LLMProvider.LITELLM: APIKeys.LITELLM_API_KEY,
         }
         return key_map.get(p, "") or ""
 
@@ -292,6 +300,43 @@ class LLMService:
         
         raise ValueError("Gemini API response is missing content")
 
+    def _call_litellm(self, messages: list, model: str, temperature: float,
+                      api_key: str, base_url: str, timeout: int,
+                      use_json_mode: bool = True) -> str:
+        """Call LLM via LiteLLM SDK (supports 100+ providers)."""
+        try:
+            import litellm
+        except ImportError as e:
+            raise ImportError(
+                "litellm is required for the LiteLLM provider. "
+                "Install it with: pip install 'litellm>=1.80,<1.87'"
+            ) from e
+
+        kwargs = {
+            "model": model,
+            "messages": messages,
+            "temperature": temperature,
+            "timeout": timeout,
+            "drop_params": True,
+        }
+
+        if use_json_mode:
+            kwargs["response_format"] = {"type": "json_object"}
+        if (api_key or "").strip():
+            kwargs["api_key"] = api_key.strip()
+        if (base_url or "").strip():
+            kwargs["api_base"] = base_url.strip().rstrip('/')
+
+        response = litellm.completion(**kwargs)
+
+        if response.choices and len(response.choices) > 0:
+            content = response.choices[0].message.content
+            if not content:
+                raise ValueError(f"Model {model} returned empty content")
+            return content
+        else:
+            raise ValueError("LiteLLM response is missing 'choices'")
+
     def _normalize_model_for_provider(self, model: str, provider: LLMProvider) -> str:
         """
         Normalize model name for the target provider.
@@ -304,8 +349,8 @@ class LLMService:
         
         model = model.strip()
         
-        # If using OpenRouter, keep the original format
-        if provider == LLMProvider.OPENROUTER:
+        # LiteLLM and OpenRouter use provider/model format natively
+        if provider in (LLMProvider.OPENROUTER, LLMProvider.LITELLM):
             return model
         
         # For direct providers, extract the model name from OpenRouter format
@@ -410,7 +455,8 @@ class LLMService:
         api_key = (self.get_api_key(p) or "").strip()
         base_url = (self.get_base_url(p) or "").strip()
         # Local OpenAI-compatible servers (e.g. Ollama) often use no API key when base_url is set.
-        custom_ok_without_key = p == LLMProvider.CUSTOM and bool(base_url)
+        # LiteLLM reads provider-specific env vars (OPENAI_API_KEY, ANTHROPIC_API_KEY, etc.) directly.
+        custom_ok_without_key = (p == LLMProvider.CUSTOM and bool(base_url)) or p == LLMProvider.LITELLM
 
         if not api_key and not custom_ok_without_key:
             # If provider is explicitly configured by user, don't silently switch.
@@ -464,7 +510,13 @@ class LLMService:
         
         for current_model in models_to_try:
             try:
-                if p == LLMProvider.GOOGLE:
+                if p == LLMProvider.LITELLM:
+                    return self._call_litellm(
+                        messages, current_model, temperature,
+                        api_key, base_url, timeout,
+                        use_json_mode=use_json_mode
+                    )
+                elif p == LLMProvider.GOOGLE:
                     return self._call_google_gemini(
                         messages, current_model, temperature,
                         api_key, base_url, timeout

--- a/backend_api_python/requirements.txt
+++ b/backend_api_python/requirements.txt
@@ -7,6 +7,7 @@ yfinance>=0.2.18
 ccxt>=4.0.0
 pandas>=1.5.0
 requests>=2.32.0
+litellm>=1.80,<1.87
 certifi>=2024.2.2
 PySocks>=1.7.1
 akshare>=1.12.0


### PR DESCRIPTION
## Summary



Adds [LiteLLM](https://github.com/BerriAI/litellm) as a new LLM provider option (`LLM_PROVIDER=litellm`), giving QuantDinger users access to 100+ LLM providers (Anthropic, Azure, Bedrock, Ollama, Groq, Together, Fireworks, etc.) through `litellm.completion()` as an SDK dependency. Additive only - all existing providers untouched.

## Changes

- `backend_api_python/app/services/llm.py`: added `LITELLM = "litellm"` to `LLMProvider` enum, `_call_litellm()` method with `drop_params=True`, dispatch in `call_llm_api()`
- `backend_api_python/app/config/api_keys.py`: added `LITELLM_API_KEY` property (optional)
- `backend_api_python/app/routes/settings.py`: added LiteLLM to provider dropdown and settings group (API Key, Model, Base URL)
- `backend_api_python/requirements.txt`: added `litellm>=1.80,<1.87`

## Test plan

- [x] Tested locally with `docker compose up -d --build`
- [x] Backend logs show no errors
- [x] Relevant pytest tests pass (691 passed, 5 skipped, 0 failed)

## API documentation (if routes/schemas changed)

- [x] No routes/schemas changed - LiteLLM added as backend provider option only
- [x] No `/api/agent/v1` routes changed
- [x] No breaking API changes

## Screenshots (if UI change)

NA
