### PR TITLE
feat: add Requesty as an OpenAI-compatible provider

### DIFF
--- a/backend_api_python/app/config/api_keys.py
+++ b/backend_api_python/app/config/api_keys.py
@@ -101,6 +101,16 @@ class MetaAPIKeys(type):
         return val if val else ''
     
     @property
+    def REQUESTY_API_KEY(cls):
+        # Always check env var first to avoid stale cache issues
+        env_val = os.getenv('REQUESTY_API_KEY', '').strip()
+        if env_val:
+            return env_val
+        from app.utils.config_loader import load_addon_config
+        val = load_addon_config().get('requesty', {}).get('api_key')
+        return val if val else ''
+    
+    @property
     def OPENAI_API_KEY(cls):
         """OpenAI direct API key"""
         env_val = os.getenv('OPENAI_API_KEY', '').strip()

--- a/backend_api_python/app/services/llm.py
+++ b/backend_api_python/app/services/llm.py
@@ -20,6 +20,7 @@ logger = get_logger(__name__)
 class LLMProvider(Enum):
     """Supported LLM providers"""
     OPENROUTER = "openrouter"
+    REQUESTY = "requesty"
     OPENAI = "openai"
     GOOGLE = "google"
     DEEPSEEK = "deepseek"
@@ -34,6 +35,11 @@ class LLMProvider(Enum):
 PROVIDER_CONFIGS = {
     LLMProvider.OPENROUTER: {
         "base_url": "https://openrouter.ai/api/v1",
+        "default_model": "openai/gpt-5.4",
+        "fallback_model": "openai/gpt-4o-mini",
+    },
+    LLMProvider.REQUESTY: {
+        "base_url": "https://router.requesty.ai/v1",
         "default_model": "openai/gpt-5.4",
         "fallback_model": "openai/gpt-4o-mini",
     },
@@ -125,6 +131,7 @@ class LLMService:
             LLMProvider.OPENAI,
             LLMProvider.GOOGLE,
             LLMProvider.OPENROUTER,
+            LLMProvider.REQUESTY,
         ]
         
         for p in priority_order:
@@ -141,6 +148,7 @@ class LLMService:
         
         key_map = {
             LLMProvider.OPENROUTER: APIKeys.OPENROUTER_API_KEY,
+            LLMProvider.REQUESTY: APIKeys.REQUESTY_API_KEY,
             LLMProvider.OPENAI: APIKeys.OPENAI_API_KEY,
             LLMProvider.GOOGLE: APIKeys.GOOGLE_API_KEY,
             LLMProvider.DEEPSEEK: APIKeys.DEEPSEEK_API_KEY,

--- a/backend_api_python/app/utils/config_loader.py
+++ b/backend_api_python/app/utils/config_loader.py
@@ -92,6 +92,9 @@ def load_addon_config() -> Dict[str, Any]:
         ('OPENROUTER_TIMEOUT', 'openrouter.timeout', 'int'),
         ('OPENROUTER_CONNECT_TIMEOUT', 'openrouter.connect_timeout', 'int'),
         
+        # Requesty (OpenAI-compatible LLM gateway)
+        ('REQUESTY_API_KEY', 'requesty.api_key', 'string'),
+        
         # OpenAI Direct
         ('OPENAI_API_KEY', 'openai.api_key', 'string'),
         ('OPENAI_BASE_URL', 'openai.base_url', 'string'),


### PR DESCRIPTION
This adds a dedicated `requesty` provider, mirroring the existing OpenRouter provider as closely as possible.

Changes:
* `backend_api_python/app/services/llm.py`: add `REQUESTY` to the `LLMProvider` enum, a `PROVIDER_CONFIGS` entry (base URL `https://router.requesty.ai/v1`), the `get_api_key` key map, and the auto-detect priority list.
* `backend_api_python/app/config/api_keys.py`: add a `REQUESTY_API_KEY` property mirroring `OPENROUTER_API_KEY` (env var first, then addon config).
* `backend_api_python/app/utils/config_loader.py`: add the `REQUESTY_API_KEY` to `requesty.api_key` env mapping.

Requesty is an OpenAI-compatible LLM gateway and uses the same `provider/model` naming as OpenRouter, so it reuses the same OpenAI-compatible client path (no new request code).

Verification: I tested the endpoint live before opening this. `GET https://router.requesty.ai/v1/models` returned 200 (around 578 models), and a chat completion with `openai/gpt-4o-mini` against `https://router.requesty.ai/v1/chat/completions` returned 200. I confirmed the enum, config, key map, and priority list all resolve `requesty` consistently.

Docs: https://requesty.ai , https://app.requesty.ai/api-keys

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust or close it if it is not a fit.
