### PR TITLE
fix: OKX spot orders below 1 unit rejected with 51000 (sz precision misread as 0 for small lotSz)

### DIFF
--- a/backend_api_python/app/services/live_trading/okx.py
+++ b/backend_api_python/app/services/live_trading/okx.py
@@ -258,21 +258,15 @@ class OkxClient(BaseRestClient):
         if lot_sz > 0:
             req = self._floor_to_step(req, lot_sz)
         
-        # Infer precision from lotSz
+        # Infer precision from lotSz. Use the Decimal exponent instead of string
+        # parsing: normalize() renders small steps in scientific notation
+        # (0.00000001 -> "1E-8", no '.'), which would misread precision as 0.
         size_precision = None
         if lot_sz > 0:
             try:
-                lot_sz_normalized = lot_sz.normalize()
-                lot_sz_str = str(lot_sz_normalized)
-                if '.' in lot_sz_str:
-                    decimal_part = lot_sz_str.split('.')[1]
-                    size_precision = len(decimal_part)
-                    if size_precision < 0:
-                        size_precision = 0
-                    if size_precision > 18:
-                        size_precision = 18
-                else:
-                    size_precision = 0
+                exp = lot_sz.normalize().as_tuple().exponent
+                if isinstance(exp, int):
+                    size_precision = min(max(0, -exp), 18)
             except Exception:
                 pass
 

--- a/backend_api_python/tests/test_okx_order_size_precision.py
+++ b/backend_api_python/tests/test_okx_order_size_precision.py
@@ -49,3 +49,14 @@ def test_swap_integer_lot_sz_precision_zero():
     )
     assert precision == 0
     assert c._dec_str(sz, strict_precision=precision) == "5"
+
+
+def test_positive_exponent_lot_sz_clamps_to_zero_precision():
+    # lotSz=10 normalizes to 1E+1 (positive exponent); max(0, -exp) must
+    # clamp precision to 0 rather than going negative.
+    c = _client_with_instrument("X-USDT", "SPOT", "10", "10")
+    sz, precision = c._normalize_order_size(
+        inst_id="X-USDT", market_type="spot", size=25.0
+    )
+    assert precision == 0
+    assert c._dec_str(sz, strict_precision=precision) == "20"

--- a/backend_api_python/tests/test_okx_order_size_precision.py
+++ b/backend_api_python/tests/test_okx_order_size_precision.py
@@ -1,0 +1,51 @@
+"""OKX order size precision inference from lotSz.
+
+Regression test: lotSz values like "0.00000001" normalize to scientific
+notation ("1E-8") under Decimal.normalize(), which the old string-based
+parser misread as precision 0 — collapsing any sub-1-unit spot order to
+sz="0" and triggering OKX error 51000 (Parameter sz error).
+"""
+
+import time
+
+from app.services.live_trading.okx import OkxClient
+
+
+def _client_with_instrument(inst_id: str, inst_type: str, lot_sz: str, min_sz: str) -> OkxClient:
+    c = OkxClient(api_key="k", secret_key="s", passphrase="p")
+    c._inst_cache[f"{inst_type}:{inst_id}"] = (
+        time.time(),
+        {"instId": inst_id, "lotSz": lot_sz, "minSz": min_sz},
+    )
+    return c
+
+
+def test_spot_small_lot_sz_keeps_fractional_size():
+    # BTC-USDT spot: lotSz=0.00000001 (1E-8 after Decimal.normalize()).
+    c = _client_with_instrument("BTC-USDT", "SPOT", "0.00000001", "0.00001")
+    sz, precision = c._normalize_order_size(
+        inst_id="BTC-USDT", market_type="spot", size=0.00081471
+    )
+    assert precision == 8
+    assert c._dec_str(sz, strict_precision=precision) == "0.00081471"
+
+
+def test_spot_regular_lot_sz_precision():
+    c = _client_with_instrument("ETH-USDT", "SPOT", "0.000001", "0.001")
+    sz, precision = c._normalize_order_size(
+        inst_id="ETH-USDT", market_type="spot", size=0.0234567891
+    )
+    assert precision == 6
+    # Floored to lot step, then rendered without exceeding precision.
+    assert c._dec_str(sz, strict_precision=precision) == "0.023456"
+
+
+def test_swap_integer_lot_sz_precision_zero():
+    # Swap contracts: lotSz=1 must keep precision 0 (whole contracts).
+    c = _client_with_instrument("BTC-USDT-SWAP", "SWAP", "1", "1")
+    c._inst_cache["SWAP:BTC-USDT-SWAP"][1]["ctVal"] = "0.01"
+    sz, precision = c._normalize_order_size(
+        inst_id="BTC-USDT-SWAP", market_type="swap", size=0.05
+    )
+    assert precision == 0
+    assert c._dec_str(sz, strict_precision=precision) == "5"


### PR DESCRIPTION
## Problem

Placing a spot market order through the OKX adapter fails with:

```
OKX error: {'code': '1', 'data': [{'sCode': '51000', 'sMsg': 'Parameter sz error', ...}], 'msg': 'All operations failed'}
```

This affects **any spot order below one whole base unit** — e.g. a 50 USDT quick-trade buy of BTC/USDT (~0.0008 BTC).

## Root cause

`OkxClient._normalize_order_size()` infers the size precision from `lotSz` by string-parsing the normalized Decimal:

```python
lot_sz_normalized = lot_sz.normalize()   # Decimal('0.00000001') -> Decimal('1E-8')
lot_sz_str = str(lot_sz_normalized)      # '1E-8' — no '.' present
if '.' in lot_sz_str:                    # not taken
    ...
else:
    size_precision = 0                   # precision misread as 0
```

`Decimal.normalize()` renders small steps in scientific notation, so BTC-USDT spot (`lotSz=0.00000001`) yields precision **0**. `_dec_str(sz, strict_precision=0)` then quantizes 0.00081471 down to `sz="0"`, which OKX rejects with 51000.

## Fix

Derive the precision from the Decimal exponent instead of parsing the string representation:

```python
exp = lot_sz.normalize().as_tuple().exponent
if isinstance(exp, int):
    size_precision = min(max(0, -exp), 18)
```

Handles `0.00000001` → 8, `0.000001` → 6, `1` → 0 (whole swap contracts), `10` → 0.

## Testing

- Added `tests/test_okx_order_size_precision.py` (3 regression tests, instrument cache pre-seeded so no network needed) — all pass; the first case fails on the old code.
- Verified end-to-end against OKX demo trading (`x-simulated-trading: 1`) via `/api/quick-trade/place-order`: a 50 USDT market buy of BTC/USDT that previously failed with 51000 now fills correctly (0.00081677 BTC @ 61246).